### PR TITLE
feat: use plain zap instead of SugaredLogger everywhere

### DIFF
--- a/cmd/theila/main.go
+++ b/cmd/theila/main.go
@@ -17,7 +17,6 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/talos-systems/theila/internal/backend"
-	"github.com/talos-systems/theila/internal/backend/logging"
 )
 
 // rootCmd represents the base command when called without any subcommands.
@@ -36,20 +35,17 @@ func main() {
 	config := zap.NewDevelopmentConfig()
 	config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 
-	zapLogger, err := config.Build()
+	logger, err := config.Build()
 	if err != nil {
 		log.Fatalf("failed to set up logging %s", err)
 	}
-
-	logger := zapLogger.Sugar()
-	logging.Logger = logger
 
 	server := backend.NewServer(rootCmdArgs.address, rootCmdArgs.port)
 
 	ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	if err := server.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		logger.Fatalf("failed to run server %s", err)
+		logger.Fatal("failed to run server", zap.Error(err))
 	}
 }
 

--- a/frontend/src/components/Preview.vue
+++ b/frontend/src/components/Preview.vue
@@ -8,9 +8,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     <div>
       <ul class="flex w-full flex-wrap items-center h-10">
         <li class="block relative">
-          <dropdown :options="sources"/>
-        </li>
-        <li class="block relative ml-4">
           <input type="text" name="resource" class="
                                      inline-flex 
                                      justify-center 
@@ -42,7 +39,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 <script lang="ts">
 import { Options, Vue } from 'vue-class-component';
-import { Source } from '../api/message';
 
 import ListView from './ListView.vue';
 import Dropdown from './Dropdown.vue';
@@ -55,7 +51,6 @@ import Dropdown from './Dropdown.vue';
 
   data() {
     return {
-      source: Source.Kubernetes,
       resource: null,
       resourceInput: "",
     }
@@ -68,6 +63,5 @@ import Dropdown from './Dropdown.vue';
   },
 })
 export default class HelloWorld extends Vue {
-  sources: Source[] = [Source.Kubernetes, Source.Talos];
 }
 </script>

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.16.0
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/protobuf v1.25.0
 	k8s.io/api v0.21.0
 	k8s.io/apimachinery v0.21.0

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -26,7 +26,7 @@ import (
 // Server is main backend entrypoint that starts REST API, WebSocket and Serves static contents.
 type Server struct {
 	ctx      context.Context
-	logger   *zap.SugaredLogger
+	logger   *zap.Logger
 	ws       *ws.Server
 	runtimes map[message.Source]runtime.Runtime
 	address  string
@@ -63,7 +63,7 @@ func (s *Server) Run(ctx context.Context) error {
 		return err
 	}
 
-	s.logger.Infof("Serving on port %d", s.port)
+	s.logger.Sugar().Infof("Serving on port %d", s.port)
 
 	server := &http.Server{
 		Addr:    fmt.Sprintf("%s:%d", s.address, s.port),

--- a/internal/backend/ws/session.go
+++ b/internal/backend/ws/session.go
@@ -23,7 +23,7 @@ type Session struct { //nolint:govet
 	cancel          context.CancelFunc
 	runtimes        map[message.Source]runtime.Runtime
 	conn            *Conn
-	logger          *zap.SugaredLogger
+	logger          *zap.Logger
 	subscriptionsMu sync.RWMutex
 	subscriptions   map[string]*Subscription
 }

--- a/internal/backend/ws/subscription.go
+++ b/internal/backend/ws/subscription.go
@@ -25,7 +25,7 @@ type Subscription struct { //nolint:govet
 
 	wg      sync.WaitGroup
 	conn    *Conn
-	logger  *zap.SugaredLogger
+	logger  *zap.Logger
 	ctx     context.Context
 	cancel  context.CancelFunc
 	runtime runtime.Runtime
@@ -87,7 +87,7 @@ func (s *Subscription) run() error {
 		return err
 	}
 
-	s.logger.Debugw("subscribed")
+	s.logger.Debug("subscribed")
 
 	return nil
 }
@@ -103,7 +103,7 @@ func (s *Subscription) handleEvent(e runtime.Event) {
 
 	defer func() {
 		if err != nil {
-			s.logger.Errorw("failed to write event to the socket", logging.ErrorContext(err)...)
+			s.logger.Error("failed to write event to the socket", zap.Error(err))
 		}
 	}()
 

--- a/internal/backend/ws/ws.go
+++ b/internal/backend/ws/ws.go
@@ -23,7 +23,7 @@ import (
 
 // Server is a websocket server.
 type Server struct {
-	logger   *zap.SugaredLogger
+	logger   *zap.Logger
 	ctx      context.Context
 	runtimes map[message.Source]runtime.Runtime
 	upgrader *websocket.Upgrader
@@ -60,13 +60,13 @@ func (ws *Server) createSession(rw http.ResponseWriter, r *http.Request) {
 		})
 
 		if err != nil {
-			ws.logger.Errorw("faield to encode error response", logging.ErrorContext(err)...)
+			ws.logger.Error("faield to encode error response", zap.Error(err))
 
 			return
 		}
 
 		if _, err = rw.Write(data); err != nil {
-			ws.logger.Errorw("failed to write error", logging.ErrorContext(err)...)
+			ws.logger.Error("failed to write error", zap.Error(err))
 		}
 
 		return
@@ -91,7 +91,7 @@ func (ws *Server) createSession(rw http.ResponseWriter, r *http.Request) {
 		case websocket.BinaryMessage:
 			request, err := proto.Decode(data)
 			if err != nil {
-				ws.logger.Errorw("failed to decode request message", logging.ErrorContext(err)...)
+				ws.logger.Error("failed to decode request message", zap.Error(err))
 
 				continue
 			}
@@ -102,23 +102,23 @@ func (ws *Server) createSession(rw http.ResponseWriter, r *http.Request) {
 
 				errResponse, err = proto.NewErrorResponse(request, err)
 				if err != nil {
-					ws.logger.Errorw("failed to encode error response", logging.ErrorContext(err)...)
+					ws.logger.Error("failed to encode error response", zap.Error(err))
 
 					continue
 				}
 
 				if err = conn.WriteProtobuf(errResponse); err != nil {
-					ws.logger.Errorw("failed to write error response", logging.ErrorContext(err)...)
+					ws.logger.Error("failed to write error response", zap.Error(err))
 				}
 
 				continue
 			}
 
 			if err = conn.WriteProtobuf(response); err != nil {
-				ws.logger.Errorw("failed to write response", logging.ErrorContext(err)...)
+				ws.logger.Error("failed to write response", zap.Error(err))
 			}
 		default:
-			ws.logger.Errorf("unhandled message type %d", mt)
+			ws.logger.Sugar().Errorf("unhandled message type %d", mt)
 		}
 	}
 }


### PR DESCRIPTION
This actually simplifies adding the context to the logs.
Using `Sugar()` only wherever we `fmt.Sprintf` something.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>