### PR TITLE
feat: implement appearance settings modal window

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4,46 +4,79 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 -->
 <template>
-  <shell v-if="connected">
-    <template v-slot:menu>
-      <router-view name="sidebar"/>
-    </template>
-    <template v-slot:content>
-      <router-view class="w-full h-full"/>
-    </template>
-  </shell>
+  <div :class="{dark: dark}">
+    <t-modal/>
+    <shell v-if="connected" class="h-screen">
+      <template v-slot:menu>
+        <router-view name="sidebar"/>
+      </template>
+      <template v-slot:content>
+        <router-view class="w-full h-full"/>
+      </template>
+    </shell>
+  </div>
 </template>
 
 <script lang="ts">
-import { Options, Vue } from 'vue-class-component';
+import { ref, onMounted, watch } from 'vue';
 import Shell from './components/Shell.vue';
-import ShellMenuItem from './components/ShellMenuItem.vue';
+import TModal from './components/TModal.vue';
 import { context } from './context';
-import {
-  ViewGridIcon,
-  ServerIcon
-} from '@heroicons/vue/outline';
+import { theme, systemTheme } from './theme';
 
-
-@Options({
+export default {
   components: {
     Shell,
-    ShellMenuItem,
-    ViewGridIcon,
-    ServerIcon,
+    TModal,
   },
 
-  data() {
-    return {
-      connected: false,
-    }
-  },
+  setup() {
+    const connected = ref(false);
+    const dark = ref(false);
 
-  mounted() {
-    context.api.connect().then(() => {
-      this.connected = true;
+    const updateTheme = (mode) => {
+      for(let i = 0; i < 2; i++) {
+        switch(mode) {
+          case "system":
+            mode = systemTheme.value;
+            break;
+          case "dark":
+            dark.value = true;
+            return;
+          case "light":
+            dark.value = false;
+            return;
+        }
+      }
+    };
+
+    onMounted(() => {
+      context.api.connect().then(() => {
+        connected.value = true;
+      });
     });
-  }
-})
-export default class App extends Vue {}
+
+    updateTheme(theme.value);
+
+    watch(
+      theme,
+      (val) => {
+        updateTheme(val);
+      }
+    );
+
+    watch(
+      systemTheme,
+      (val) => {
+        if(theme.value === "system")
+          updateTheme(val);
+      }
+    );
+
+    return {
+      connected,
+      dark
+    };
+  },
+};
 </script>

--- a/frontend/src/components/Shell.vue
+++ b/frontend/src/components/Shell.vue
@@ -4,12 +4,76 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 -->
 <template>
-  <div class="flex flex-row h-screen font-sans antialiased bg-white dark:bg-talos-gray-900 text-talos-gray-900 dark:text-white">
-    <div class="flex flex-col justify-between flex-none h-full py-2 select-none bg-talos-gray-200 w-72 dark:bg-talos-gray-800">
+  <div :class="shellClasses">
+    <div :class="sidebarClasses" :style="style">
       <slot name="menu"></slot>
     </div>
-    <div class="flex flex-col w-full h-full overflow-x-hidden overflow-y-scroll bg-white dark:bg-talos-gray-900 py-2 px-4">
+    <div :class="contentClasses">
       <slot name="content"></slot>
     </div>
   </div>
 </template>
+
+<script type="ts">
+import { Options, Vue } from 'vue-class-component';
+
+@Options({
+  props: {
+    colorStyle: {
+      type: String,
+      default: "normal",
+    },
+
+    sidebarWidth: {
+      type: String,
+      default: "18rem",
+    }
+  },
+
+  computed: {
+    sidebarClasses() {
+      return `sidebar sidebar-${this.colorStyle}`;
+    },
+
+    contentClasses() {
+      return `content-${this.colorStyle}`;
+    },
+
+    shellClasses() {
+      return `shell-${this.colorStyle}`;
+    },
+
+    style() {
+      return `width: ${this.sidebarWidth};`;
+    }
+  }
+})
+export default class Shell extends Vue {}
+</script>
+
+<style>
+.sidebar-inverted {
+  @apply flex flex-col justify-between flex-none h-full py-2 select-none px-3;
+}
+
+.sidebar-normal {
+  @apply sidebar-inverted bg-talos-gray-200 dark:bg-talos-gray-800;
+}
+
+.content-inverted {
+  @apply flex flex-col w-full h-full overflow-x-hidden overflow-y-auto py-2 px-4;
+}
+
+.content-normal {
+  @apply content-inverted bg-white dark:bg-talos-gray-900;
+}
+
+.shell-normal {
+  @apply shell-inverted bg-white dark:bg-talos-gray-900 text-talos-gray-900 dark:text-white;
+}
+
+.shell-inverted {
+  @apply flex flex-row font-sans antialiased;
+}
+
+</style>

--- a/frontend/src/components/ShellMenuItem.vue
+++ b/frontend/src/components/ShellMenuItem.vue
@@ -4,9 +4,9 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 -->
 <template>
-  <div class="px-3">
+  <div>
     <div class="flex flex-col gap-2">
-      <component :is="link ? 'router-link' : 'a'" :to="link" class="link">
+      <component :is="link ? 'router-link' : 'a'" :to="link" :class="{'shell-menu-link': true, 'router-link-active': active, 'cursor-pointer': true}">
         <div class="flex flex-row items-center gap-2">
           <slot name="icon"></slot>
           <span class="text-sm leading-none font-medium">{{ name }}</span>
@@ -23,17 +23,23 @@ import { Options, Vue } from 'vue-class-component';
   props: {
     name: String,
     link: Object,
+    active: Boolean,
   },
 })
 export default class ShellMenuItem extends Vue {}
 </script>
 
-<style scoped>
-.link {
+<style>
+.shell-menu-link {
   @apply flex flex-row items-center justify-between w-full px-3 py-2 rounded-md dark:text-talos-gray-50 text-talos-gray-900 hover:bg-talos-gray-50 dark:hover:bg-talos-gray-700;
 }
 
-.link.router-link-active {
+.shell-menu-link.router-link-active {
   @apply dark:bg-talos-gray-700 bg-talos-gray-50;
+}
+
+.sidebar-inverted .shell-menu-link.router-link-active,
+.sidebar-inverted .shell-menu-link:hover {
+  @apply dark:text-talos-gray-100 text-talos-gray-900 dark:bg-talos-gray-700 bg-talos-gray-200;
 }
 </style>

--- a/frontend/src/components/TModal.vue
+++ b/frontend/src/components/TModal.vue
@@ -1,0 +1,67 @@
+<!--
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+<template>
+  <div class="container-modal" v-if="view" @click.self="close">
+    <div class="py-5">
+      <div class="px-5">
+        <h3 class="mb-2 text-lg leading-6 font-medium text-talos-gray-900 dark:text-talos-gray-100" id="modal-title">{{ view.title }}</h3>
+      </div>
+      <component :is="view.component"/>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Options, Vue } from 'vue-class-component';
+import { modals } from '../router';
+
+@Options({
+  data() {
+    return {
+      view: null,
+    }
+  },
+
+  mounted() {
+    this.updateState();
+  },
+
+  watch: {
+    '$route'() {
+      this.updateState();
+    }
+  },
+
+  methods: {
+    updateState() {
+      const modal = this.$route.query.modal ? modals[this.$route.query.modal] : null;
+
+      if(modal) {
+        this.view = modal;
+      } else {
+        this.view = null;
+      }
+    },
+
+    close() {
+      this.$router.replace({ query: {
+        modal: undefined,
+      }});
+    }
+  }
+})
+export default class TModal extends Vue {}
+</script>
+
+<style scoped>
+.container-modal {
+  @apply fixed bg-talos-gray-200 dark:bg-black bg-opacity-50 dark:bg-opacity-50 w-screen h-screen flex items-center justify-center transition-all transition;
+}
+
+.container-modal > * {
+  @apply align-middle w-full max-w-3xl bg-white dark:bg-talos-gray-800 rounded-lg text-left overflow-hidden shadow-xl transform;
+}
+</style>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -11,6 +11,7 @@ import Services from "../views/node/Services.vue";
 import SidebarRoot from "../views/SidebarRoot.vue";
 import SidebarCluster from "../views/SidebarCluster.vue";
 import SidebarNode from "../views/SidebarNode.vue";
+import Settings from "../views/Settings.vue";
 
 const withPrefix = (prefix, routes) => 
     routes.map( (route) => {
@@ -86,4 +87,12 @@ const router = createRouter({
   routes,
 });
 
+const modals = {
+  settings: {
+    title: "Settings",
+    component: Settings,
+  }
+};
+
+export { modals };
 export default router;

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { ref, watch } from "vue";
+
+const systemTheme = ref(window.matchMedia('(prefers-color-scheme: dark)').matches ? "dark" : "light");
+const theme = ref(localStorage.theme || "system");
+
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
+  systemTheme.value = e.matches ? "dark" : "light";
+});
+
+watch(
+  theme,
+  (v) => {
+    localStorage.theme = v;
+  }
+)
+
+export { theme, systemTheme };

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -1,0 +1,86 @@
+<!--
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+<template>
+  <shell color-style="inverted" sidebar-width="12rem" class="px-2">
+    <template v-slot:menu>
+      <shell-menu-item name="Appearance" active="true">
+        <template v-slot:icon>
+          <eye-icon class="w-6 h-6"/>
+        </template>
+      </shell-menu-item>
+    </template>
+    <template v-slot:content>
+      <fieldset>
+        <legend class="sr-only">Theme setting</legend>
+        <div class="bg-white dark:bg-talos-gray-900 rounded-md -space-y-px form-radio-group">
+          <label v-for="opt in options" :key="opt.value" class="border-talos-gray-200 dark:border-talos-gray-600 relative border p-4 flex cursor-pointer">
+            <input type="radio" v-model="theme" name="theme_setting" :value="opt.value" class="h-4 w-4 mt-0.5 cursor-pointer text-blue-600 border-talos-gray-300 focus:ring-blue-500" aria-labelledby="theme-setting-0-label" aria-describedby="theme-setting-0-description" />
+            <div class="ml-3 flex flex-col">
+              <span id="theme-setting-0-label" class="text-talos-gray-900 dark:text-talos-gray-100 block text-sm font-medium"> {{ opt.label }} </span>
+              <span id="theme-setting-0-description" class="text-talos-gray-900 dark:text-talos-gray-100 block text-sm"> {{ opt.description }} </span>
+            </div>
+          </label>
+        </div>
+      </fieldset>
+    </template>
+  </shell>
+</template>
+
+<script lang="ts">
+import Shell from '../components/Shell.vue';
+import ShellMenuItem from '../components/ShellMenuItem.vue';
+import { theme } from '../theme';
+import {
+  EyeIcon,
+} from '@heroicons/vue/outline';
+
+export default {
+  components: {
+    Shell,
+    ShellMenuItem,
+    EyeIcon,
+  },
+
+  setup() {
+    return {
+      theme,
+      options: [
+        {
+          label: "Light Theme",
+          value: "light",
+          description: "The default theme for the Sidero application.",
+        },
+        {
+          label: "Dark Theme",
+          value: "dark",
+          description: "An alternative theme that’s easy on the eyes.",
+        },
+        {
+          label: "System",
+          value: "system",
+          description: "Automatically switch between light and dark themes when your system does.",
+        },
+      ]
+    }
+  },
+
+  methods: {
+    changeTheme(e) {
+      theme.value = e.target.value;
+    }
+  }
+}
+</script>
+
+<style scoped>
+.form-radio-group > label:first-child {
+  @apply rounded-tl-md rounded-tr-md;
+}
+
+.form-radio-group > label:last-child {
+  @apply rounded-bl-md rounded-br-md;
+}
+</style>

--- a/frontend/src/views/SidebarRoot.vue
+++ b/frontend/src/views/SidebarRoot.vue
@@ -18,7 +18,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
         <server-icon class="w-6 h-6"/>
       </template>
     </shell-menu-item>
-    <shell-menu-item name="Settings">
+    <shell-menu-item @click="openSettings" name="Settings">
       <template v-slot:icon>
         <cog-icon class="w-6 h-6"/>
       </template>
@@ -42,6 +42,12 @@ import {
     ServerIcon,
     CogIcon,
   },
+
+  methods: {
+    openSettings() {
+      this.$router.replace({query: {modal: "settings"}});
+    }
+  }
 })
 export default class SidebarRoot extends Vue {}
 </script>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -5,7 +5,7 @@ module.exports = {
   purge: {
     content: ['./public/**/*.html', './src/**/*.vue']
   },
-  darkMode: 'media',
+  darkMode: 'class',
   theme: {
     fontFamily: {
       sans: ['Inter var', ...defaultTheme.fontFamily.sans],


### PR DESCRIPTION
Introduced a generic primitives for viewing modal windows.

Also reused shell component in settings view.

This PR helped to learn more about Vue 3 composition API primitives like
`ref` and `watch`.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>