### PR TITLE
feat: decouple watch list from the view

### DIFF
--- a/frontend/src/api/watch.ts
+++ b/frontend/src/api/watch.ts
@@ -1,0 +1,241 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { reactive, ref } from 'vue';
+import { Client, Callback, ClientReconnected } from './client';
+import { Source, Context } from '../common/theila';
+import { Message, WatchSpec, UnsubscribeSpec, Kind } from './message';
+import { v4 as uuidv4 } from 'uuid';
+
+export class SubscriptionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SubscriptionError";
+  }
+}
+
+export interface CompareFunc {
+  (a: Object, b: Object): number;
+}
+
+export default class Watch {
+  private client: Client;
+  private source?: Source;
+  private resource?: Object;
+  private uid!: string;
+  private callback: Callback;
+  private context?: Object;
+  private handler?: any;
+  private compare?: CompareFunc;
+
+  public items: any;
+  public loading: any;
+  public err: any;
+  public running: any;
+
+  constructor(client: Client) {
+    this.client = client;
+    this.handler = this.handleReconnect.bind(this);
+
+    this.items = ref([]);
+    this.loading = ref(false);
+    this.err = ref("");
+    this.running = ref(false);
+
+    this.callback = (message: Message) => {
+      const spec = JSON.parse(message.spec);
+      let index = 0;
+      let foundIndex = -1;
+
+      switch(message.kind) {
+        case Kind.EventItemAdd:
+          foundIndex = this.findIndex(spec);
+          if(foundIndex != -1) {
+            return;
+          }
+
+          index = getInsertionIndex(this.items.value, spec, this.compare);
+
+          this.items.value.splice(index, 0, spec);
+
+          break;
+        case Kind.EventItemDelete:
+          foundIndex = this.findIndex(spec);
+          if(foundIndex != -1) {
+            this.items.value.splice(foundIndex, 1);
+          }
+          break;
+        case Kind.EventItemUpdate:
+          foundIndex = this.findIndex(spec["old"]);
+          if(foundIndex != -1) {
+            this.items.value[foundIndex] = spec["new"];
+          }
+          break;
+        case Kind.EventError:
+          this.stop();
+          this.err.value = spec;
+          break;
+      }
+    };
+  }
+
+  public async start(source: Source, resource: Object, context?: Object, compare?: CompareFunc): Promise<Message> {
+    this.loading.value = true;
+    this.err.value = "";
+    this.items.value.splice(0, this.items.value.length);
+
+    this.source = source;
+    this.resource = resource;
+    this.context = context;
+    this.compare = compare;
+
+    const params = {
+      resource: this.resource,
+      source: this.source,
+    }
+
+    if (this.context) {
+      params["context"] = Context.fromPartial(this.context);
+    }
+
+    const watchSpec = WatchSpec.fromPartial(params);
+
+    const watchRequest = newMessage(
+      Kind.Watch,
+      watchSpec,
+    );
+
+    let message:Message;
+
+    try {
+      message = await this.client.send(watchRequest);
+
+      if (!message.spec) {
+        throw new Error("empty spec in the response");
+      }
+
+      const spec = JSON.parse(message.spec);
+
+      this.client.subscribe(spec["uid"], this.callback);
+      this.uid = spec["uid"];
+
+      this.client.addListener(ClientReconnected, this.handler);
+    } catch(err) {
+      this.err.value = err;
+      throw err;
+    } finally {
+      this.loading.value = false;
+    }
+
+    this.running.value = true;
+
+    return message;
+  }
+
+  public stop(): Promise<Message> {
+    this.items.value.splice(0, this.items.value.length);
+    this.running = false;
+
+    if (!this.uid) {
+      return Promise.reject(new SubscriptionError("failed to stop: not subscribed"));
+    }
+
+    if (!this.client.unsubscribe(this.uid, this.callback)) {
+      return Promise.reject(new SubscriptionError("failed to stop: not subscribed"))
+    }
+
+    const unsubscribe = newMessage(
+      Kind.Unsubscribe,
+      UnsubscribeSpec.fromPartial({
+        uid: this.uid,
+      }),
+    );
+
+    this.uid = null!;
+    this.client.removeListener(ClientReconnected, this.handler);
+
+    return this.client.send(unsubscribe);
+  }
+
+  public async handleReconnect() {
+    if (this.uid == null || this.source == null || this.resource == null) {
+      return;
+    }
+
+    try {
+      await this.start(this.source, this.resource, this.context, this.compare);
+    } catch(e) {
+      console.log("failed to restart watch", e)
+    }
+  }
+
+  private findIndex(item: Object): number {
+    if(!this.items.value) {
+      return -1;
+    }
+
+    return this.items.value.findIndex(element => {
+      return this.id(element) === this.id(item);
+    })
+  }
+
+  public id(item: Object): string {
+    if(item["metadata"] == null) {
+      return "";
+    }
+
+    const name = this.source === Source.Kubernetes ? item["metadata"]["name"] : item["metadata"]["id"];
+
+    return `${item["metadata"]["namespace"]}.${name}`;
+  }
+}
+
+function newMessage(kind: Kind, spec: any): Message {
+  return Message.fromPartial({
+    kind: kind,
+    metadata: {
+      uid: uuidv4(),
+    },
+    spec: JSON.stringify(spec),
+  });
+}
+
+function getInsertionIndex(arr: Object[], item: Object, compare?: CompareFunc): number {
+  const itemsCount = arr.length;
+  if (compare == null) {
+    return itemsCount;
+  }
+
+  if (itemsCount === 0) {
+    return 0;
+  }
+
+  const lastItem = arr[itemsCount - 1];
+
+  if (compare(item, lastItem) >= 0) {
+    return itemsCount;
+  }
+
+  const getMidPoint = (start, end) => Math.floor((end - start) / 2) + start;
+  let start = 0;
+  let end = itemsCount - 1;
+  let index = getMidPoint(start, end);
+
+  while (start < end) {
+    const curItem = arr[index];
+
+    const comparison = compare(item, curItem);
+
+    if (comparison === 0) {
+      break;
+    } else if (comparison < 0) {
+      end = index;
+    } else {
+      start = index + 1;
+    }
+    index = getMidPoint(start, end);
+  }
+
+  return index;
+}

--- a/frontend/src/components/ClusterListItem.vue
+++ b/frontend/src/components/ClusterListItem.vue
@@ -17,7 +17,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
               >
               {{ item.metadata.name }}
             </p>
-            <div class="flex items-center mt-2 text-sm text-talos-gray-500 dark:text-talos-gray-400">
+            <div class="flex items-center mt-2 text-sm text-talos-gray-500 dark:text-talos-gray-400" v-if="item.status">
               <div v-if="item.status.phase === 'Provisioned'">
                 <check-circle-icon
                   class="flex-shrink-0 mr-1.5 h-5 w-5 text-green-400"
@@ -33,7 +33,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
               <span class="truncate">{{ item.status.phase }}</span>
             </div>
           </div>
-          <div class="block">
+          <div class="block" v-if="item.status">
             <div>
               <p
                 v-if="nodesCount >= 0"

--- a/frontend/src/views/Clusters.vue
+++ b/frontend/src/views/Clusters.vue
@@ -8,7 +8,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     <div class="px-3 py-2 mb-2">
       <h1 class="text-lg tracking-tight text-talos-gray-900 dark:text-white font-bold">Clusters</h1>
     </div>
-    <stacked-list class="flex-1" resource="clusters.v1alpha3.cluster.x-k8s.io" idField="metadata.name" :provider="0">
+    <stacked-list class="flex-1" :resource="{type: 'clusters.v1alpha3.cluster.x-k8s.io'}" kubernetes>
       <template v-slot:default="slot">
         <cluster-list-item :item="slot.item"/>
       </template>

--- a/frontend/src/views/Servers.vue
+++ b/frontend/src/views/Servers.vue
@@ -8,7 +8,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     <div class="px-3 py-2 mb-2">
       <div class="text-lg tracking-tight text-talos-gray-900 dark:text-white font-bold">Servers</div>
     </div>
-    <stacked-list class="flex-1" resource="servers.v1alpha1.metal.sidero.dev" idField="metadata.name" :provider="0">
+    <stacked-list class="flex-1" :resource="{type: 'servers.v1alpha1.metal.sidero.dev'}" kubernetes>
       <template v-slot:default="slot">
         <a
           class="block hover:bg-talos-gray-50 dark:hover:bg-talos-gray-800"
@@ -32,7 +32,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
                 </div>
                 <div class="block">
                   <div class="flex items-center text-sm text-talos-gray-500 dark:text-talos-gray-400">
-                    <div v-if="slot.item.status.ready">
+                    <div v-if="slot.item.status && slot.item.status.ready">
                       <check-circle-icon
                         class="flex-shrink mr-1.5 h-5 w-5 text-green-400"
                         aria-hidden="true"

--- a/frontend/src/views/cluster/Nodes.vue
+++ b/frontend/src/views/cluster/Nodes.vue
@@ -10,11 +10,10 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     </div>
     <stacked-list 
         class="flex-1"
-        resource="nodes.v1"
-        idField="metadata.name"
+        :resource="{type: 'nodes.v1'}"
         showCount
         itemName="Node"
-        :provider="0"
+        kubernetes
         :context="{cluster: {name: $route.params.cluster, namespace: $route.params.namespace, uid: $route.params.uid}}">
       <template v-slot:header>
         <div class="flex items-center md:grid md:grid-cols-5">

--- a/frontend/src/views/cluster/Pods.vue
+++ b/frontend/src/views/cluster/Pods.vue
@@ -10,9 +10,8 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     </div>
     <stacked-list 
       class="flex-1"
-      resource="pods.v1"
-      idField="metadata.name"
-      :provider="0"
+      :resource="{type: 'pods.v1'}"
+      kubernetes
       showCount
       itemName="Pod"
       :context="{cluster: {name: $route.params.cluster, namespace: $route.params.namespace, uid: $route.params.uid}}">

--- a/frontend/src/views/node/Services.vue
+++ b/frontend/src/views/node/Services.vue
@@ -10,11 +10,10 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     </div>
     <stacked-list 
         class="flex-1"
-        resource="services"
-        idField="metadata.id"
+        :resource="{type: 'services'}"
         showCount
         itemName="Service"
-        :provider="1"
+        talos
         :context="{cluster: {name: $route.params.cluster, namespace: $route.params.namespace, uid: $route.params.uid, nodes: [$route.params.node]}}">
       <template v-slot:header>
         <div class="flex items-center md:grid md:grid-cols-8">

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ replace (
 require (
 	github.com/containernetworking/cni v0.8.1 // indirect
 	github.com/cosi-project/runtime v0.0.0-20210423184025-225827c8b0d8
+	github.com/gertd/go-pluralize v0.1.7
 	github.com/go-logr/logr v0.2.1 // indirect
 	github.com/golang/protobuf v1.5.2
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,7 @@ github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoD
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/gertd/go-pluralize v0.1.7 h1:RgvJTJ5W7olOoAks97BOwOlekBFsLEyh00W48Z6ZEZY=
 github.com/gertd/go-pluralize v0.1.7/go.mod h1:O4eNeeIf91MHh1GJ2I47DNtaesm66NYvjYgAahcqSDQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/theila/issues/16

Now watch object maintains the item list by itself, which is at the same
time is reactive and can be used in any UI elements.

Also introduced sort methods with default being by namespace and id.
And fixed item lookup to consider not only resource name but also
namespace.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>