### PR TITLE
feat: make stacked lists searchable

### DIFF
--- a/frontend/src/components/ServerListItem.vue
+++ b/frontend/src/components/ServerListItem.vue
@@ -75,7 +75,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
           <div class="tag details-tag">
             <check-icon class="w-5 h-5" v-if="item.spec.accepted"/>
             <x-icon class="w-5 h-5" v-else/>
-            {{ capitalize(item.spec.accepted) }}
+            {{ capitalize(item.spec.accepted || false) }}
           </div>
         </div>
         <div class="flex-1">
@@ -83,7 +83,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
           <div class="tag details-tag">
             <check-icon class="w-5 h-5" v-if="item.status.isClean"/>
             <x-icon class="w-5 h-5" v-else/>
-            {{ capitalize(item.status.isClean) }}
+            {{ capitalize(item.status.isClean || false) }}
           </div>
         </div>
         <div class="flex-1">
@@ -99,7 +99,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
           <div class="tag details-tag">
             <check-icon class="w-5 h-5" v-if="item.status.inUse"/>
             <x-icon class="w-5 h-5" v-else/>
-            {{ capitalize(item.status.inUse) }}
+            {{ capitalize(item.status.inUse || false) }}
           </div>
         </div>
       </div>

--- a/frontend/src/components/TInput.vue
+++ b/frontend/src/components/TInput.vue
@@ -4,13 +4,18 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 -->
 <template>
-  <input 
-    type="text" 
-    :class="{'py-2': !small, 'py-1': small, 'focus:border-blue-500': true, 'dark:focus:border-talos-blue-600': true}"
-    :placeholder="placeholder"
-    :value="modelValue"
-    @input="$emit('update:modelValue', $event.target.value)"
-  />
+  <div class="relative">
+    <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none text-talos-gray-500" v-if="$slots.icon">
+      <slot name="icon"/>
+    </div>
+    <input 
+      type="text"
+      :class="{'py-2': !small, 'py-1': small, 'icon-padding': $slots.icon, 'focus:border-blue-500': true, 'dark:focus:border-talos-blue-600': true, 'w-full': true}"
+      :placeholder="placeholder"
+      :value="modelValue"
+      @input="$emit('update:modelValue', $event.target.value)"
+    />
+  </div>
 </template>
 
 <script lang="ts">
@@ -25,6 +30,10 @@ export default {
 
 <style scoped>
 input {
-  @apply px-3 text-sm font-normal leading-5 bg-white dark:bg-black border rounded-md shadow-none appearance-none placeholder-talos-gray-400 dark:placeholder-talos-gray-500 text-talos-gray-700 dark:text-talos-gray-200 border-talos-gray-300 dark:border-talos-gray-600 sm:max-w-xs focus:outline-none focus:ring ring-blue-200 dark:ring-gray-700;
+  @apply px-3 text-sm font-normal leading-5 bg-white dark:bg-black border rounded-md shadow-none appearance-none placeholder-talos-gray-400 dark:placeholder-talos-gray-500 text-talos-gray-700 dark:text-talos-gray-200 border-talos-gray-300 dark:border-talos-gray-600 focus:outline-none focus:ring ring-blue-200 dark:ring-gray-700;
+}
+
+input.icon-padding {
+  @apply pl-10;
 }
 </style>

--- a/frontend/src/components/Watch.vue
+++ b/frontend/src/components/Watch.vue
@@ -12,7 +12,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
       {{ err }}.
     </t-alert>
     <t-alert v-else-if="items.length == 0" type="info" title="No Records">No entries of the requested resource type are found on the server.</t-alert>
-    <stacked-list v-else :items="items" :idFn="resourceWatch.id" :showCount="showCount" :itemName="itemName">
+    <stacked-list v-else :items="items" :idFn="resourceWatch.id" :showCount="showCount" :itemName="itemName" :search="search" :filterFn="filterFn">
       <template v-slot:header v-if="$slots.header">
         <slot name="header"></slot>
       </template>
@@ -43,6 +43,8 @@ export default {
     context: Object,
     showCount: Boolean,
     itemName: String,
+    search: String,
+    filterFn: Function,
     compareFn: Function,
     kubernetes: Boolean,
     talos: Boolean,

--- a/frontend/src/views/Clusters.vue
+++ b/frontend/src/views/Clusters.vue
@@ -8,7 +8,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     <div class="px-3 py-2">
       <h1 class="text-lg tracking-tight text-talos-gray-900 dark:text-white font-bold">Clusters</h1>
     </div>
-    <watch class="flex-1" :resource="{type: 'clusters.v1alpha3.cluster.x-k8s.io'}" kubernetes>
+    <watch class="flex-1" :resource="{type: 'clusters.v1alpha3.cluster.x-k8s.io'}" kubernetes search="Search cluster by name">
       <template v-slot:default="slot">
         <cluster-list-item :item="slot.item"/>
       </template>

--- a/frontend/src/views/Servers.vue
+++ b/frontend/src/views/Servers.vue
@@ -25,7 +25,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
         </template>
       </t-stat>
     </div>
-    <watch class="flex-1" :watch="servers">
+    <watch class="flex-1" :watch="servers" search="Search server" :filterFn="search">
       <template v-slot:header>
         <div class="flex items-center md:grid md:grid-cols-5">
           <div class="col-span-2 block">
@@ -110,6 +110,22 @@ export default {
 
         return (100 - getAllocated()).toFixed(0) + "%";
       }),
+      search(item, filter) {
+        if(item["metadata"]["name"].includes(filter)) {
+          return true;
+        }
+
+        if(item["spec"]["cpu"]["version"].includes(filter)) {
+          return true;
+        }
+
+        const labels = item["metadata"]["labels"] || {};
+        for(const key in labels) {
+          return key.includes(filter) || labels[key].includes(filter);
+        }
+
+        return false;
+      }
     };
   }
 };

--- a/frontend/src/views/cluster/Nodes.vue
+++ b/frontend/src/views/cluster/Nodes.vue
@@ -17,6 +17,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
         showCount
         itemName="Node"
         kubernetes
+        search="Search node by name"
         :context="getContext()">
       <template v-slot:header>
         <div class="flex items-center md:grid md:grid-cols-5">

--- a/frontend/src/views/cluster/Pods.vue
+++ b/frontend/src/views/cluster/Pods.vue
@@ -17,6 +17,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
       kubernetes
       showCount
       itemName="Pod"
+      search="Search pod by name"
       :context="getContext()">
       <template v-slot:header>
         <div class="flex items-center md:grid md:grid-cols-6">

--- a/frontend/src/views/node/Services.vue
+++ b/frontend/src/views/node/Services.vue
@@ -14,6 +14,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
         showCount
         itemName="Service"
         talos
+        search="Search service by name"
         :context="getContext()">
       <template v-slot:header>
         <div class="flex items-center md:grid md:grid-cols-8">


### PR DESCRIPTION
Enabled searching by name for any of the resources we display.
Additionally search servers by labels and cpu version.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>