### PR TITLE
feat: allow filtering servers by picking from predefined categories

### DIFF
--- a/cmd/theila/main.go
+++ b/cmd/theila/main.go
@@ -54,7 +54,6 @@ var rootCmdArgs struct {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		log.Printf("execute error %s", err)
 		os.Exit(1)
 	}
 }

--- a/frontend/src/components/TDropdown.vue
+++ b/frontend/src/components/TDropdown.vue
@@ -58,7 +58,7 @@ export default {
 
 <style>
 .dropdown-items a {
-  @apply block px-4 py-2 text-sm text-talos-gray-700 dark:text-talos-gray-50;
+  @apply block px-4 py-2 text-sm text-talos-gray-700 dark:text-talos-gray-50 cursor-default;
 }
 
 .dropdown-items a.active {

--- a/frontend/src/components/Watch.vue
+++ b/frontend/src/components/Watch.vue
@@ -12,7 +12,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
       {{ err }}.
     </t-alert>
     <t-alert v-else-if="items.length == 0" type="info" title="No Records">No entries of the requested resource type are found on the server.</t-alert>
-    <stacked-list v-else :items="items" :idFn="resourceWatch.id" :showCount="showCount" :itemName="itemName" :search="search" :filterFn="filter">
+    <stacked-list v-else :items="items" :idFn="resourceWatch.id" :showCount="showCount" :itemName="itemName" :search="search" :filterFn="filter" :categories="categories">
       <template v-slot:header v-if="$slots.header">
         <slot name="header"></slot>
       </template>
@@ -43,6 +43,7 @@ export default {
     context: Object,
     showCount: Boolean,
     itemName: String,
+    categories: Array,
     search: String,
     filterFn: Function,
     compareFn: Function,

--- a/frontend/src/views/Servers.vue
+++ b/frontend/src/views/Servers.vue
@@ -25,7 +25,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
         </template>
       </t-stat>
     </div>
-    <watch class="flex-1" :watch="servers" search="Search server" :filterFn="search">
+    <watch class="flex-1" :watch="servers" search="Search server" :filterFn="search" :categories="categories">
       <template v-slot:header>
         <div class="flex items-center md:grid md:grid-cols-5">
           <div class="col-span-2 block">
@@ -90,11 +90,32 @@ export default {
     servers.setup(props, {});
 
     const getAllocated = () => {
-
       return items.value.filter((item) => item["status"]["inUse"]).length / items.value.length * 100;
     };
 
+    const categories = [
+      {
+        placeholder: "All Servers",
+        options: [
+          { name: "In Use", filter: (item) => item["status"]["inUse"] },
+          { name: "Not In Use", filter: (item) => !item["status"]["inUse"] },
+          { name: "Accepted", filter: (item) => item["spec"]["accepted"] },
+          { name: "Not Accepted", filter: (item) => !item["spec"]["accepted"] },
+          { name: "On", filter: (item) => item["status"]["power"] === 'on' },
+          { name: "Off", filter: (item) => item["status"]["power"] === 'off' },
+        ]
+      },
+      {
+        placeholder: "All Statuses",
+        options: [
+          { name: "Ready", filter: (item) => item["status"]["ready"] },
+          { name: "Error", filter: (item) => !item["status"]["ready"] },
+        ]
+      }
+    ];
+
     return {
+      categories,
       items,
       servers,
       loading: servers.loading,

--- a/internal/backend/server_test.go
+++ b/internal/backend/server_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"testing"
@@ -77,7 +78,8 @@ func (s *ServerSuite) SetupTest() {
 
 	s.runtime = &testRuntime{}
 
-	s.server, err = backend.NewServer("", 3000)
+	port := 35000 + rand.Intn(6000)
+	s.server, err = backend.NewServer("", port)
 
 	s.Require().NoError(err)
 
@@ -89,7 +91,7 @@ func (s *ServerSuite) SetupTest() {
 		return s.server.Run(s.ctx)
 	})
 
-	u := url.URL{Scheme: "ws", Host: "0.0.0.0:3000", Path: "/ws"}
+	u := url.URL{Scheme: "ws", Host: fmt.Sprintf("0.0.0.0:%d", port), Path: "/ws"}
 
 	var (
 		c    *websocket.Conn


### PR DESCRIPTION
Added that function to the `Watch` and `StackedList` so it can be
actually used in any other lists we have.

 + Address tests flakiness by using different ports for the gRPC proxy.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>