### PR TITLE
feat: add ability to pick sort order on the servers page

### DIFF
--- a/frontend/src/api/watch.ts
+++ b/frontend/src/api/watch.ts
@@ -30,6 +30,7 @@ export default class Watch {
   private handler?: any;
   private compare?: CompareFunc;
 
+  public sort: Ref<CompareFunc>;
   public items?: any;
   public loading: any;
   public err: any;
@@ -42,9 +43,15 @@ export default class Watch {
     this.loading = ref(false);
     this.err = ref("");
     this.running = ref(false);
+    this.sort = ref(defaultCompareFunc(this));
 
-    if(items)
+    if(items) {
       this.items = items;
+
+      watch(this.sort, () => {
+        this.items.value.sort(this.sort.value);
+      });
+    }
 
     this.callback = (message: Message) => {
       const spec = JSON.parse(message.spec);
@@ -74,7 +81,7 @@ export default class Watch {
             return;
           }
 
-          index = getInsertionIndex(this.items.value, spec, this.compare);
+          index = getInsertionIndex(this.items.value, spec, this.sort.value);
 
           this.items.value.splice(index, 0, spec);
 
@@ -344,7 +351,7 @@ function getInsertionIndex(arr: Object[], item: Object, compare?: CompareFunc): 
   return index;
 }
 
-function defaultCompareFunc(w: Watch) {
+export function defaultCompareFunc(w: Watch) {
   return (a, b) => {
     if(w.id(a) === w.id(b)) {
       return 0;

--- a/frontend/src/components/StackedList.vue
+++ b/frontend/src/components/StackedList.vue
@@ -22,6 +22,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
           </menu-item>
         </template>
       </t-dropdown>
+      <slot name="menu"></slot>
     </div>
     <div class="stacked-list">
       <ul>

--- a/frontend/src/components/Watch.vue
+++ b/frontend/src/components/Watch.vue
@@ -13,6 +13,17 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     </t-alert>
     <t-alert v-else-if="items.length == 0" type="info" title="No Records">No entries of the requested resource type are found on the server.</t-alert>
     <stacked-list v-else :items="items" :idFn="(item) => resourceWatch.id(item)" :showCount="showCount" :itemName="itemName" :search="search" :filterFn="filter" :categories="categories">
+      <template v-slot:menu v-if="sortOptions">
+        <t-dropdown :title="'Sorted by: ' + sortName">
+          <menu-item v-for="option in sortOptions" :key="option.name" v-slot="{ active }">
+            <a
+              v-on:click="() => { sortFn = option.function; sortName = option.name }"
+              :class="{ active }"
+              >{{ option.name }}</a
+            >
+          </menu-item>
+        </t-dropdown>
+      </template>
       <template v-slot:header v-if="$slots.header">
         <slot name="header"></slot>
       </template>
@@ -26,15 +37,20 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 <script lang="ts">
 import { ref, toRefs, computed } from "vue";
 import { context as ctx } from "../context";
+import { MenuItem } from '@headlessui/vue';
+import { defaultCompareFunc } from "../api/watch";
 import Watch from "../api/watch";
 import TSpinner from './TSpinner.vue';
 import TAlert from './TAlert.vue';
+import TDropdown from './TDropdown.vue';
 import StackedList from './StackedList.vue';
 
 export default {
   components: {
     TSpinner,
     TAlert,
+    TDropdown,
+    MenuItem,
     StackedList,
   },
 
@@ -46,6 +62,7 @@ export default {
     categories: Array,
     search: String,
     filterFn: Function,
+    sortOptions: Object,
     compareFn: Function,
     kubernetes: Boolean,
     talos: Boolean,
@@ -53,11 +70,20 @@ export default {
   },
 
   setup(props, context) {
-    const { filterFn } = toRefs(props);
+    const { filterFn, sortOptions } = toRefs(props);
     const resourceWatch = props.watch ? props.watch : new Watch(
       ctx.api,
       ref([]),
     );
+
+    const sortName = ref("Default");
+
+    if(sortOptions && sortOptions.value) {
+      sortOptions.value.splice(0, 0, {
+        name: "Default",
+        function: defaultCompareFunc(resourceWatch),
+      });
+    }
 
     if(!props.watch) {
       resourceWatch.setup(props, context);
@@ -68,6 +94,8 @@ export default {
       err: resourceWatch.err,
       loading: resourceWatch.loading,
       running: resourceWatch.running,
+      sortFn: resourceWatch.sort,
+      sortName,
       resourceWatch,
       filter: computed(() => {
         return filterFn && filterFn.value ? filterFn.value : (item, filter) => resourceWatch.id(item).includes(filter);

--- a/frontend/src/views/Servers.vue
+++ b/frontend/src/views/Servers.vue
@@ -25,7 +25,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
         </template>
       </t-stat>
     </div>
-    <watch class="flex-1" :watch="servers" search="Search server" :filterFn="search" :categories="categories">
+    <watch class="flex-1" :watch="servers" search="Search server" :filterFn="search" :categories="categories" :sortOptions="sortOptions">
       <template v-slot:header>
         <div class="flex items-center md:grid md:grid-cols-5">
           <div class="col-span-2 block">
@@ -114,8 +114,26 @@ export default {
       }
     ];
 
+    const newest = (a, b) => {
+      const timestamp1 = a["metadata"]["creationTimestamp"];
+      const timestamp2 = b["metadata"]["creationTimestamp"];
+
+      if(timestamp1 === timestamp2)
+        return 0;
+      else if(timestamp1 < timestamp2)
+        return 1;
+
+      return -1;
+    };
+
+    const sortOptions = [
+      { name: "Newest", function: newest },
+      { name: "Oldest", function: (a, b) => newest(a, b) * -1 },
+    ];
+
     return {
       categories,
+      sortOptions,
       items,
       servers,
       loading: servers.loading,


### PR DESCRIPTION
Sort options are configurable by the input rules, so it's easy to add
that on the other pages as soon as we decide on what options we want to
have there.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>