### PR TITLE
feat: use updated timestamp to display event time on the graph

### DIFF
--- a/frontend/src/components/TChart.vue
+++ b/frontend/src/components/TChart.vue
@@ -39,6 +39,7 @@ import { context as ctx } from "../context";
 import {
   ExclamationIcon
 } from '@heroicons/vue/outline';
+import { DateTime } from 'luxon';
 
 export default {
   components: {
@@ -121,10 +122,16 @@ export default {
           continue;
         }
 
-        points.push(data[key]);
+        let point = data[key];
+        const updated = spec["new"]["metadata"]["updated"];
+        if(updated) {
+          point = [DateTime.fromISO(updated).toMillis(), point];
+        }
+
+        points.push(point);
         meta.version = version;
 
-        if(points.length > numPoints.value) {
+        if(points.length >= numPoints.value) {
           points.splice(0, 1);
         }
       }
@@ -181,6 +188,9 @@ export default {
         stroke: stroke.value,
         tooltip: {
           theme: dark.value ? "dark" : "light",
+          x: {
+            format: 'HH:mm:ss',
+          },
         },
         grid: {
           borderColor: dark.value ? '#333' : "#EEE",
@@ -197,8 +207,14 @@ export default {
           },
         },
         xaxis:{ 
+          type: "datetime",
           labels: {
-            show: false,
+            datetimeFormatter: {
+              year: 'yyyy',
+              month: 'MMM \'yy',
+              day: 'dd MMM',
+              hour: 'HH:mm'
+            }
           },
           axisBorder: {
             show: false,

--- a/frontend/src/views/node/Services.vue
+++ b/frontend/src/views/node/Services.vue
@@ -54,6 +54,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
                 class="text-sm font-medium truncate text-talos-gray-900 dark:text-talos-gray-100"
                 >
                 <check-circle-icon class="ok" v-if="slot.item.spec.healthy"/>
+                <question-mark-circle-icon class="info" v-else-if="slot.item.spec.unknown"/>
                 <exclamation-circle-icon class="error" v-else/>
               </p>
             </div>
@@ -69,6 +70,7 @@ import Watch from '../../components/Watch.vue';
 import TBreadcrumbs from '../../components/TBreadcrumbs.vue';
 import {
   CheckCircleIcon,
+  QuestionMarkCircleIcon,
   XCircleIcon,
   ExclamationCircleIcon
 } from '@heroicons/vue/outline';
@@ -80,6 +82,7 @@ export default {
     TBreadcrumbs,
     Watch,
     CheckCircleIcon,
+    QuestionMarkCircleIcon,
     XCircleIcon,
     ExclamationCircleIcon,
   },
@@ -105,6 +108,10 @@ export default {
 <style scoped>
 .ok {
   @apply h-5 w-5 text-green-400;
+}
+
+.info {
+  @apply h-5 w-5 text-blue-400;
 }
 
 .error {


### PR DESCRIPTION
Now as each Talos resource has created and updated timestamp, it is
possible to properly display event timestamp on the graph.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>