### PR TITLE
feat: implement node reboot controls

### DIFF
--- a/frontend/src/api/grpc.ts
+++ b/frontend/src/api/grpc.ts
@@ -100,17 +100,23 @@ export class Stream {
       try {
         this.err.value = null;
 
-        await method(params, handler, this.options);
+        await method(params, (resp) => {
+          if(resp.metadata && resp.metadata.error) {
+            throw new Error(resp.metadata.error);
+          } else {
+            handler(resp);
+          }
+        }, this.options);
       } catch(e) {
         handler({
           error: e,
         });
 
-        this.err.value = e;
+        this.err.value = e.toString();
         throw e;
       }
     }, backoffOptions).catch((e) => {
-      this.err.value = e;
+      this.err.value = e.toString();
     });
   }
 

--- a/frontend/src/components/NodeListItem.vue
+++ b/frontend/src/components/NodeListItem.vue
@@ -1,0 +1,202 @@
+<!--
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+<template>
+  <router-link
+    :to="{name: 'Overview', params: { node: ip }, query: getQuery() }"
+    class="block hover:bg-talos-gray-50 dark:hover:bg-talos-gray-800 flex"
+    >
+    <div class="flex-1 flex items-center px-4 py-3 sm:px-6 min-w-0 md:grid md:grid-cols-7 md:gap-4">
+      <div class="block justify-self-left">
+        <p
+          class="text-sm font-medium truncate text-talos-gray-900 dark:text-talos-gray-100"
+          >
+          {{ item.metadata.name }}
+        </p>
+      </div>
+      <div class="block justify-self-center">
+        <p
+          class="text-sm font-medium truncate text-talos-gray-900 dark:text-talos-gray-100"
+          >
+          {{ ip }}
+        </p>
+      </div>
+      <div class="justify-self-center">
+        {{ os }}
+      </div>
+      <div class="col-span-2 block justify-self-center">
+        <p
+          class="text-sm font-medium truncate text-talos-gray-900 dark:text-talos-gray-100 space-x-1 space-y-1"
+          >
+          <t-label v-for="role in roles" v-bind:key="role">{{ role }}</t-label>
+        </p>
+      </div>
+      <div class="justify-self-center">
+        <t-label :col="status === 'ready' ? 'green' : 'red'" class="uppercase">
+          <template v-slot:icon>
+            <check-circle-icon class="w-5 h-5" v-if="status === 'ready'"/>
+            <exclamation-circle-icon class="w-5 h-5" v-else/>
+          </template>
+          {{ status }}
+        </t-label>
+      </div>
+      <div v-on:click.stop.prevent.self class="justify-self-end">
+        <t-dropdown xs :disabled="!isTalos">
+          <template v-slot:icon>
+            <dots-horizontal-icon
+              class="w-5 h-5 text-talos-gray-900 dark:text-talos-gray-50"
+              aria-hidden="true"
+              />
+          </template>
+          <template v-slot:default>
+            <menu-item v-slot="{ active }">
+              <a
+                v-on:click="rebootNode"
+                :class="{ active }"
+                >Reboot</a
+              >
+            </menu-item>
+          </template>
+        </t-dropdown>
+      </div>
+    </div>
+  </router-link>
+</template>
+
+<script type="ts">
+import { useRoute } from 'vue-router';
+import { computed, toRefs } from 'vue';
+import TDropdown from '../components/TDropdown.vue';
+import TLabel from '../components/TLabel.vue';
+import { MenuItem } from '@headlessui/vue';
+import {
+  DotsHorizontalIcon,
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+} from '@heroicons/vue/solid';
+import { useRouter } from 'vue-router';
+
+export default {
+  components: {
+    TDropdown,
+    TLabel,
+    MenuItem,
+    DotsHorizontalIcon,
+    CheckCircleIcon,
+    ExclamationCircleIcon,
+  },
+
+  props: {
+    item: {
+      type: Object,
+      required: true,
+    }
+  },
+
+  setup(props) {
+    const { item } = toRefs(props);
+    const router = useRouter();
+
+    const getField = (...args) => {
+      let res = item.value;
+      for(const k of args) {
+        if(!res[k])
+          return null;
+
+        res = res[k];
+      }
+
+      return res;
+    };
+
+    const os = computed(() => {
+      return getField("status", "nodeInfo", "osImage") || "";
+    });
+
+    const ip = computed(() => {
+      const addresses = getField("status", "addresses");
+      if(!addresses)
+        return "unknown";
+
+      let addr;
+      for(const a of addresses) {
+        if (a.type == "InternalIP") {
+          addr = a.address;
+        }
+
+        if (a.type == "ExternalIP") {
+          addr = a.address;
+          break;
+        }
+      }
+
+      return addr;
+    });
+
+    const status = computed(() => {
+      const conditions = getField("status", "conditions");
+      if(!conditions)
+        return "not ready";
+
+      for(const c of conditions) {
+        if(c["type"] === "Ready" && c["status"] === "True")
+          return "ready";
+      }
+
+      return "not ready";
+    });
+
+    const roles = computed(() => {
+      const roles = [];
+
+      for (const label in item.value.metadata.labels) {
+        if (label.indexOf("node-role.kubernetes.io/") != -1) {
+          roles.push(label.split("/")[1]);
+        }
+      }
+
+      return roles;
+    });
+
+    // primitive check that this is a Talos node
+    const isTalos = computed(() => {
+      return os.value.indexOf("Talos") != -1;
+    });
+
+    const route = useRoute();
+
+    const getQuery = () => {
+      const query = {};
+
+      if(route.query.cluster && route.query.namespace && route.query.uid) {
+        query.cluster = route.query.cluster;
+        query.namespace = route.query.namespace || "default";
+        query.uid = route.query.uid;
+      }
+
+      return query;
+    };
+
+    const rebootNode = async () => {
+      router.replace({
+        query: {
+          modal: "reboot",
+          node: ip.value,
+        }
+      })
+    };
+
+    return {
+      os,
+      ip,
+      status,
+      roles,
+      isTalos,
+      rebootNode,
+      getQuery,
+    }
+  }
+};
+</script>

--- a/frontend/src/components/ServerListItem.vue
+++ b/frontend/src/components/ServerListItem.vue
@@ -11,7 +11,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
           <chevron-up-icon class="w-5 h-5"/>
         </div>
       </button>
-      <div class="flex-1 block">
+      <div class="flex-1 block truncate overflow-hidden">
         <p
           class="text-sm font-medium truncate text-talos-gray-900 dark:text-talos-gray-100"
           >

--- a/frontend/src/components/ShellMenuItem.vue
+++ b/frontend/src/components/ShellMenuItem.vue
@@ -31,7 +31,7 @@ export default class ShellMenuItem extends Vue {}
 
 <style>
 .shell-menu-link {
-  @apply flex flex-row items-center justify-between w-full px-3 py-2 rounded-md dark:text-talos-gray-50 text-talos-gray-900 hover:bg-talos-gray-50 dark:hover:bg-talos-gray-700;
+  @apply flex flex-row items-center justify-between w-full px-3 py-2 rounded-md dark:text-talos-gray-50 text-talos-gray-900 hover:bg-talos-gray-50 dark:hover:bg-talos-gray-700 transition-colors duration-200;
 }
 
 .shell-menu-link.router-link-active {

--- a/frontend/src/components/StackedList.vue
+++ b/frontend/src/components/StackedList.vue
@@ -118,7 +118,7 @@ export default {
 
 <style>
 .stacked-list {
-  @apply flex flex-col w-full bg-white border rounded-md border-talos-gray-300 dark:border-talos-gray-600 dark:bg-talos-gray-900 text-talos-gray-900 dark:text-talos-gray-100 overflow-visible;
+  @apply flex flex-col w-full bg-white border rounded-md border-talos-gray-300 dark:border-talos-gray-600 dark:bg-talos-gray-900 text-talos-gray-900 dark:text-talos-gray-100 overflow-visible mb-2;
 }
 
 .stacked-list > ul {

--- a/frontend/src/components/TButton.vue
+++ b/frontend/src/components/TButton.vue
@@ -4,9 +4,9 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 -->
 <template>
-  <button type="button" 
-          class="focus:outline-none focus:shadow-outline"
-          :class="{primary: primary, secondary: !primary, small: small, xs: xs}">
+  <button type="button" :disabled="disabled"
+          class="focus:outline-none focus:shadow-outline disabled:opacity-50"
+          :class="{primary: primary, secondary: !primary, small: small, xs: xs, 'cursor-pointer': !disabled, 'pointer-events-none': disabled}">
     <div class="container space-x-1">
       <slot></slot>
     </div>
@@ -21,6 +21,7 @@ import { Options, Vue } from 'vue-class-component';
     primary: Boolean,
     small: Boolean,
     xs: Boolean,
+    disabled: Boolean,
   },
 
   data() {

--- a/frontend/src/components/TDropdown.vue
+++ b/frontend/src/components/TDropdown.vue
@@ -6,8 +6,8 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 <template>
   <div>
     <Menu as="div" class="relative">
-      <menu-button as="template">
-        <t-button :xs="xs" :small="small">
+      <menu-button as="template" :disabled="disabled">
+        <t-button :xs="xs" :small="small" :disabled="disabled">
           {{ title }}
           <slot name="icon" v-if="$slots.icon"></slot>
           <chevron-down-icon v-else class="w-5 h-5 ml-2 -mr-1" aria-hidden="true"/>
@@ -52,6 +52,7 @@ export default {
     icon: Object,
     small: Boolean,
     xs: Boolean,
+    disabled: Boolean,
   }
 };
 </script>

--- a/frontend/src/components/TLabel.vue
+++ b/frontend/src/components/TLabel.vue
@@ -1,0 +1,61 @@
+<!--
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+<template>
+  <span :class="{tag: true, red: col === 'red', gray: col === 'gray', green: col === 'green'}">
+    <span
+      class="icon"
+      :class="{ red: col === 'red', green: col === 'green' }"
+      v-if="$slots.icon"
+      >
+      <slot name="icon"></slot>
+    </span>
+    <slot></slot>
+  </span>
+</template>
+
+<script lang="ts">
+export default {
+  props: {
+    col: {
+      type: String,
+      default: "gray",
+      validator(val) {
+        return ["red", "green", "gray"].includes(val);
+      }
+    }
+  }
+};
+</script>
+
+<style scoped>
+.tag {
+  @apply font-normal inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-sm leading-4 tracking-wider whitespace-nowrap;
+}
+
+.gray {
+  @apply bg-talos-gray-200 text-talos-gray-800 dark:bg-talos-gray-700 dark:text-talos-gray-100;
+}
+
+.red {
+  @apply bg-red-100 text-red-700 dark:bg-red-800 dark:text-red-100;
+}
+
+.green {
+  @apply bg-green-100 text-green-700 dark:bg-green-800 dark:text-green-100;
+}
+
+.icon {
+  @apply mr-1;
+}
+
+.icon.green {
+  @apply text-green-400 dark:text-green-300;
+}
+
+.icon.red {
+  @apply text-red-400 dark:text-red-300;
+}
+</style>

--- a/frontend/src/components/TNotification.vue
+++ b/frontend/src/components/TNotification.vue
@@ -1,0 +1,70 @@
+<!--
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+<template>
+  <div class="sm:flex sm:items-start p-5 max-w-2xl">
+    <div class="flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full sm:mx-0 sm:h-10 sm:w-10" :class="{ error: error, info: info, warning: warning }">
+      <exclamation-icon v-if="error || warning" class="w-6 h-6" fill="currentColor"/>
+      <information-circle-icon v-else class="w-6 h-6" fill="currentColor"/>
+    </div>
+    <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+      <h3 class="text-lg leading-6 font-medium text-talos-gray-900 dark:text-talos-gray-100" id="modal-title">{{ title }}</h3>
+      <div class="mt-2">
+        <p class="text-sm text-talos-gray-500 dark:text-talos-gray-300">{{ body }}</p>
+      </div>
+    </div>
+  </div>
+  <div class="bg-talos-gray-50 dark:bg-talos-gray-700 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse gap-2">
+    <t-button small primary @click="close">Dismiss</t-button>
+  </div>
+</template>
+
+<script lang="ts">
+import {
+  ExclamationIcon,
+  InformationCircleIcon,
+} from '@heroicons/vue/outline';
+import { modal } from '../modal';
+import TButton from './TButton.vue';
+
+export default {
+  components: {
+    ExclamationIcon,
+    InformationCircleIcon,
+    TButton,
+  },
+
+  props: {
+    title: String,
+    body: String,
+    error: Boolean,
+    info: Boolean,
+    warning: Boolean,
+  },
+
+  setup() {
+    return {
+      close() {
+        modal.value = null;
+      }
+    }
+  },
+}
+</script>
+
+<style scoped>
+.warning {
+  @apply text-yellow-400  bg-yellow-400 bg-opacity-20;
+}
+
+.error {
+  @apply bg-red-100 dark:bg-red-300 text-red-600 dark:bg-opacity-20;
+}
+
+.info {
+  @apply bg-blue-400 dark:bg-blue-300 text-blue-400 dark:text-blue-300 bg-opacity-20;
+}
+</style>
+

--- a/frontend/src/context.ts
+++ b/frontend/src/context.ts
@@ -2,12 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import { ref } from 'vue';
+import { ref, Ref } from 'vue';
 import { Client } from "./api/client";
 import { ResourceService } from './api/grpc';
 
-// create a singleton.
 export namespace context {
+  // create a singleton for the api.
   export const api:Client = new Client();
 
   export const current:any = ref(localStorage.context ? JSON.parse(localStorage.context) : null);

--- a/frontend/src/modal.ts
+++ b/frontend/src/modal.ts
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { ref, Ref, Component } from 'vue';
+import TNotification from './components/TNotification.vue';
+
+export type Modal = {
+  component: Component,
+  props?: Object,
+};
+
+export const modal: Ref<any> = ref(null);
+
+export const showError = (title: string, body: string) => {
+  modal.value = {
+    component: TNotification,
+    props: {
+      title: title,
+      body: body,
+      error: true,
+    }
+  }
+};

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -14,6 +14,7 @@ import SidebarRoot from "../views/SidebarRoot.vue";
 import SidebarCluster from "../views/SidebarCluster.vue";
 import SidebarNode from "../views/SidebarNode.vue";
 import Settings from "../views/Settings.vue";
+import Reboot from "../views/Reboot.vue";
 import { useRoute } from 'vue-router';
 import { context } from '../context';
 
@@ -134,10 +135,8 @@ const router = createRouter({
 });
 
 const modals = {
-  settings: {
-    title: "Settings",
-    component: Settings,
-  }
+  settings: Settings,
+  reboot: Reboot,
 };
 
 export { modals };

--- a/frontend/src/views/Reboot.vue
+++ b/frontend/src/views/Reboot.vue
@@ -1,0 +1,88 @@
+<!--
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+<template>
+  <div class="sm:flex sm:items-start p-5 max-w-xl">
+    <div class="flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-yellow-400 text-yellow-400 bg-opacity-20 sm:mx-0 sm:h-10 sm:w-10">
+      <exclamation-icon class="w-6 h-6" fill="currentColor"/>
+    </div>
+    <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+      <h3 class="text-lg leading-6 font-medium text-talos-gray-900 dark:text-talos-gray-100" id="modal-title">Reboot the Node {{ node }}</h3>
+      <div class="mt-2">
+        <p class="text-sm text-talos-gray-500 dark:text-talos-gray-300">Please confirm the action.</p>
+      </div>
+    </div>
+  </div>
+  <div class="bg-talos-gray-50 dark:bg-talos-gray-700 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse gap-2">
+    <t-button small primary :disabled="!node || state === 'Rebooting'" @click="reboot">{{ state }}</t-button>
+    <t-button small @click="close">Cancel</t-button>
+  </div>
+</template>
+
+<script lang="ts">
+import TButton from '../components/TButton.vue';
+import { ref } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { MachineService, getCluster } from '../api/grpc';
+import { Source } from '../common/theila.pb';
+import {
+  ExclamationIcon,
+} from '@heroicons/vue/outline';
+import { showError } from '../modal';
+
+export default {
+  components: {
+    TButton,
+    ExclamationIcon,
+  },
+
+  setup() {
+    const route = useRoute();
+    const router = useRouter();
+    const state = ref("Reboot");
+
+    const close = () => {
+      router.replace({ query: {
+        modal: undefined,
+        node: undefined,
+      }});
+    };
+
+    return {
+      node: route.query.node,
+      state,
+      close,
+      reboot: async () => {
+        state.value = "Rebooting";
+
+        try {
+          const res = await MachineService.Reboot({}, {
+            source: Source.Talos,
+            metadata: {
+              nodes: [route.query.node],
+              ...getCluster(route),
+            }
+          });
+
+          const errors: string[] = [];
+          for(const message of res.messages) {
+            if(message.metadata.error)
+              errors.push(`${message.metadata.hostname || route.query.node} ${message.metadata.error}`);
+          }
+
+          if(errors.length > 0)
+            throw new Error(errors.join(", "))
+
+          close();
+        } catch(e) {
+          close();
+
+          showError("Failed to Issue Reboot", e.toString())
+        }
+      }
+    }
+  },
+}
+</script>

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -4,29 +4,34 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 -->
 <template>
-  <shell color-style="inverted" sidebar-width="12rem" class="px-2">
-    <template v-slot:menu>
-      <shell-menu-item name="Appearance" active="true">
-        <template v-slot:icon>
-          <eye-icon class="w-6 h-6"/>
-        </template>
-      </shell-menu-item>
-    </template>
-    <template v-slot:content>
-      <fieldset>
-        <legend class="sr-only">Theme setting</legend>
-        <div class="bg-white dark:bg-talos-gray-900 rounded-md -space-y-px form-radio-group">
-          <label v-for="opt in options" :key="opt.value" class="border-talos-gray-200 dark:border-talos-gray-600 relative border p-4 flex cursor-pointer">
-            <input type="radio" v-model="theme" name="theme_setting" :value="opt.value" class="h-4 w-4 mt-0.5 cursor-pointer text-blue-600 border-talos-gray-300 focus:ring-blue-500" aria-labelledby="theme-setting-0-label" aria-describedby="theme-setting-0-description" />
-            <div class="ml-3 flex flex-col">
-              <span id="theme-setting-0-label" class="text-talos-gray-900 dark:text-talos-gray-100 block text-sm font-medium"> {{ opt.label }} </span>
-              <span id="theme-setting-0-description" class="text-talos-gray-900 dark:text-talos-gray-100 block text-sm"> {{ opt.description }} </span>
-            </div>
-          </label>
-        </div>
-      </fieldset>
-    </template>
-  </shell>
+  <div class="py-5 w-full max-w-3xl">
+    <div class="px-5">
+      <h3 class="mb-2 text-lg leading-6 font-medium text-talos-gray-900 dark:text-talos-gray-100" id="modal-title">Settings</h3>
+    </div>
+    <shell color-style="inverted" sidebar-width="12rem" class="px-2">
+      <template v-slot:menu>
+        <shell-menu-item name="Appearance" active="true">
+          <template v-slot:icon>
+            <eye-icon class="w-6 h-6"/>
+          </template>
+        </shell-menu-item>
+      </template>
+      <template v-slot:content>
+        <fieldset>
+          <legend class="sr-only">Theme setting</legend>
+          <div class="bg-white dark:bg-talos-gray-900 rounded-md -space-y-px form-radio-group">
+            <label v-for="opt in options" :key="opt.value" class="border-talos-gray-200 dark:border-talos-gray-600 relative border p-4 flex cursor-pointer">
+              <input type="radio" v-model="theme" name="theme_setting" :value="opt.value" class="h-4 w-4 mt-0.5 cursor-pointer text-blue-600 border-talos-gray-300 focus:ring-blue-500" aria-labelledby="theme-setting-0-label" aria-describedby="theme-setting-0-description" />
+              <div class="ml-3 flex flex-col">
+                <span id="theme-setting-0-label" class="text-talos-gray-900 dark:text-talos-gray-100 block text-sm font-medium"> {{ opt.label }} </span>
+                <span id="theme-setting-0-description" class="text-talos-gray-900 dark:text-talos-gray-100 block text-sm"> {{ opt.description }} </span>
+              </div>
+            </label>
+          </div>
+        </fieldset>
+      </template>
+    </shell>
+  </div>
 </template>
 
 <script lang="ts">

--- a/frontend/src/views/cluster/Nodes.vue
+++ b/frontend/src/views/cluster/Nodes.vue
@@ -20,118 +20,47 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
         search="Search node by name"
         :context="getContext()">
       <template v-slot:header>
-        <div class="flex items-center md:grid md:grid-cols-5">
-          <div class="col-span-2 block">
+        <div class="flex items-center md:grid md:grid-cols-7">
+          <div class="block justify-self-left">
             Name
           </div>
-          <div class="block">
+          <div class="block justify-self-center">
             IP
           </div>
-          <div class="col-span-2 block">
+          <div class="justify-self-center">
+            OS
+          </div>
+          <div class="col-span-2 block justify-self-center">
             Roles
+          </div>
+          <div class="justify-self-center">
+            Status
           </div>
         </div>
       </template>
       <template v-slot:default="slot">
-        <router-link
-          :to="{name: 'Overview', params: { node: getIP(slot.item) }, query: getQuery() }"
-          class="block hover:bg-talos-gray-50 dark:hover:bg-talos-gray-800"
-          >
-          <div class="flex items-center px-4 py-4 sm:px-6 min-w-0 md:grid md:grid-cols-5 md:gap-4">
-            <div class="col-span-2 block">
-              <p
-                class="text-sm font-medium truncate text-talos-gray-900 dark:text-talos-gray-100"
-                >
-                {{ slot.item.metadata.name }}
-              </p>
-            </div>
-            <div class="block">
-              <p
-                class="text-sm font-medium truncate text-talos-gray-900 dark:text-talos-gray-100"
-                >
-                {{ getIP(slot.item) }}
-              </p>
-            </div>
-            <div class="col-span-2 block">
-              <p
-                class="text-sm font-medium truncate text-talos-gray-900 dark:text-talos-gray-100 space-x-1 space-y-1"
-                >
-                <span v-for="role in getRoles(slot.item)" v-bind:key="role">{{ role }}</span>
-              </p>
-            </div>
-          </div>
-        </router-link>
+        <node-list-item :item="slot.item"/>
       </template>
     </watch>
   </div>
 </template>
 
 <script type="ts">
-import { useRoute } from 'vue-router';
 import { getContext } from '../../router';
 import Watch from '../../components/Watch.vue';
 import TBreadcrumbs from '../../components/TBreadcrumbs.vue';
+import NodeListItem from '../../components/NodeListItem.vue';
 
 export default {
   components: {
     Watch,
     TBreadcrumbs,
+    NodeListItem,
   },
 
   setup() {
-    const route = useRoute();
-
-    const getIP = (item) => {
-      const status = item.status;
-      let addr = "unknown";
-
-      if (status == null) {
-        return addr;
-      }
-
-      for (const a of status.addresses) {
-        if (a.type == "InternalIP") {
-          addr = a.address;
-        }
-
-        if (a.type == "ExternalIP") {
-          addr = a.address;
-          break;
-        }
-      }
-
-      return addr;
-    };
-
-    const getRoles = (item) => {
-      const roles = [];
-
-      for (const label in item.metadata.labels) {
-        if (label.indexOf("node-role.kubernetes.io/") != -1) {
-          roles.push(label.split("/")[1]);
-        }
-      }
-
-      return roles;
-    };
-
-    const getQuery = () => {
-      const query = {};
-
-      if(route.query.cluster && route.query.namespace && route.query.uid) {
-        query.cluster = route.query.cluster;
-        query.namespace = route.query.namespace || "default";
-        query.uid = route.query.uid;
-      }
-
-      return query;
-    };
-
     return {
-      getIP,
-      getRoles,
       getContext,
-      getQuery,
     };
   },
 };

--- a/frontend/src/views/node/Logs.vue
+++ b/frontend/src/views/node/Logs.vue
@@ -8,10 +8,10 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     <div class="flex-0 px-3 py-2 mb-2">
       <t-breadcrumbs>{{ $route.params.node }} {{ $route.params.service }} Logs</t-breadcrumbs>
     </div>
-    <t-alert v-if="err" title="Failed to Fetch Logs" type="error">
+    <t-alert v-if="err" :title="logs ? 'Disconnected' : 'Failed to Fetch Logs'" type="error" class="mb-2">
       {{ err }}.
     </t-alert>
-    <div v-else class="flex-1 pb-3 logs">
+    <div v-if="logs.length > 0" class="flex-1 pb-3 logs">
       <div class="flex border-b border-talos-gray-300 dark:border-talos-gray-600 p-4 gap-1">
         <div class="flex-1">{{ logs.length }} lines</div>
         <div class="flex items-center justify-center gap-2 text-talos-gray-800 hover:text-talos-gray-600 dark:text-talos-gray-400 dark:hover:text-talos-gray-300">
@@ -102,13 +102,20 @@ export default {
         }
       }
 
+      let clearLogs = false;
+
       stream.value = subscribe(method, params, (resp) => {
         clearTimeout(flush);
 
         if(resp.error) {
-          reset();
+          clearLogs = true;
           return;
         }
+
+        if(clearLogs)
+          reset();
+
+        clearLogs = false;
 
         buffer += atob(resp.bytes);
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -18,7 +18,9 @@ module.exports = {
     },
   },
   variants: {
-    extend: {},
+    extend: {
+      opacity: ["disabled"],
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
Add that functional to the `Nodes` page.
Now there's a dropdown menu that has reboot option, which opens the
modal dialog to confirm the reboot.

If it fails to issue reboot command we show failure notification popup.

Additionally add readiness status to each node on the nodes page.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>