### PR TITLE
fix: accumulate chart updates into a single update

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,11 +5,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
-    <title><%= htmlWebpackPlugin.options.title %></title>
+    <title>Sidero UI</title>
   </head>
   <body>
     <noscript>
-      <strong>We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+      <strong>We're sorry but Sidero UI doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/theila/issues/55

During the initial load it gets all points as a separate updates.
Accumulate them into a single one to stop Vue from overloading the
renderer.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>