### PR TITLE
fix: node IP not being truncated

### DIFF
--- a/frontend/src/api/grpc.ts
+++ b/frontend/src/api/grpc.ts
@@ -15,7 +15,7 @@ import { Runtime, Context, Cluster } from './common/theila.pb';
 import { ManagementService as WrappedManagementService } from './rpc/management.pb';
 import { MachineService as WrappedMachineService } from './talos/machine/machine.pb';
 import { GetRequest, ListRequest, Metadata, Spec } from './talos/resource/resource.pb';
-import { context, getContext } from '../context';
+import { contextName } from '../context';
 import { backOff, IBackOffOptions } from "exponential-backoff";
 import { ref, Ref } from 'vue';
 import { RouteLocationNormalized } from 'vue-router';
@@ -62,8 +62,9 @@ export class Options {
     const md = metadata ? metadata : {};
     md["runtime"] = runtime.toString();
 
-    if(context.current.value) {
-      md["context"] = md["context"] || getContext(runtime);
+    const currentContext = contextName();
+    if(currentContext) {
+      md["context"] = md["context"] || currentContext;
     }
 
     for(const key in md) {
@@ -205,6 +206,8 @@ export class ResourceService {
   
   static async GetConfig(cluster: Cluster, options?: Partial<OptionsPartial>): Promise<string> {
     const res = await WrappedResourceService.GetConfig(cluster, Options.fromPartial(options));
+
+    checkError(res);
 
     if(!res.data) {
       return "";

--- a/frontend/src/api/watch.ts
+++ b/frontend/src/api/watch.ts
@@ -7,7 +7,7 @@ import { Client, Callback, ClientReconnected } from './client';
 import { Runtime, Context, runtimeFromJSON } from './common/theila';
 import { Message, WatchSpec, UnsubscribeSpec, Kind } from './socket/message';
 import { v4 as uuidv4 } from 'uuid';
-import { context as ctx } from '../context';
+import { context as ctx, contextName } from '../context';
 
 export class SubscriptionError extends Error {
   constructor(message: string) {
@@ -151,10 +151,8 @@ export default class Watch {
       }
 
       // override the context name by the current default one unless it's explicitly defined
-      if(ctx.current.value) {
-        if(!componentContext.context || !componentContext.context.name)
-          c["name"] = source == Runtime.Kubernetes ? ctx.current.value.name : ctx.current.value.cluster;
-      }
+      if(!componentContext.context || !componentContext.context.name)
+        c["name"] = contextName();
 
       this.start(
         source,

--- a/frontend/src/components/NodeListItem.vue
+++ b/frontend/src/components/NodeListItem.vue
@@ -16,7 +16,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
           {{ item.metadata.name }}
         </p>
       </div>
-      <div class="block justify-self-center">
+      <div class="block justify-self-left">
         <p
           class="text-sm font-medium truncate text-talos-gray-900 dark:text-talos-gray-100"
           >

--- a/frontend/src/context.ts
+++ b/frontend/src/context.ts
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import { ref, Ref } from 'vue';
+import { useRoute } from 'vue-router';
 import { Client } from "./api/client";
 import { ResourceService, RequestError } from './api/grpc';
 import { Runtime } from './api/common/theila.pb';
@@ -27,11 +28,28 @@ export function changeContext(c: Object) {
   context.current.value = c;
 }
 
-export function getContext(runtime: Runtime): string | null {
-  if(context.current.value === null)
-    return null;
 
-  return runtime === Runtime.Talos ? context.current.value.cluster : context.current.value.name;
+export function getContext() {
+  const route = useRoute();
+
+  const name = contextName();
+
+  if(route.query.namespace && route.query.cluster && route.query.uid) {
+    return {
+      cluster: {
+        name: route.query.cluster,
+        namespace: route.query.namespace || "default",
+        uid: route.query.uid
+      },
+      name: name,
+    };
+  }
+
+  return name ? { name: name } : null;
+}
+
+export function contextName(): string | null {
+  return context.current.value ? context.current.value.name : null;
 }
 
 export async function detectCapabilities() {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -60,22 +60,6 @@ export function getSidebar(route) {
   return SidebarRoot;
 }
 
-export function getContext() {
-  const route = useRoute();
-
-  if(route.query.namespace && route.query.cluster && route.query.uid) {
-    return {
-      cluster: {
-        name: route.query.cluster,
-        namespace: route.query.namespace || "default",
-        uid: route.query.uid
-      }
-    };
-  }
-
-  return null;
-}
-
 const routes = [
   {
     path: "/",

--- a/frontend/src/views/Upgrade.vue
+++ b/frontend/src/views/Upgrade.vue
@@ -99,18 +99,15 @@ export default {
     };
 
     const cluster = getCluster(route);
-    const contextName = getContext(Runtime.Talos);
-    const ctx = {
-      name: contextName,
-      cluster: Object.keys(cluster).length === 0 ? null : cluster,
-    };
+    const ctx = getContext() || {};
+    const contextName = ctx["name"];
 
     const handleStatusChange = (message, spec) => {
       if(message.kind != Kind.EventItemUpdate)
         return;
 
       const old = spec["old"]["spec"];
-      const current = spec["new"]["spec"]
+      const current = spec["new"]["spec"];
 
       if(old["phase"] !== current["phase"] && current["phase"] === TaskStatusSpec_Phase.COMPLETE) {
         close();
@@ -140,7 +137,7 @@ export default {
       try {
         const response = await ContextService.List();
         
-        upgradeID.value = `${cluster["uid"] || getContext(Runtime.Kubernetes) || response.currentContext}-upgrade-k8s`;
+        upgradeID.value = `${cluster["uid"] || contextName || response.currentContext}-upgrade-k8s`;
 
         await statusWatch.start(Runtime.Theila, {
           id: upgradeID.value,

--- a/frontend/src/views/cluster/Nodes.vue
+++ b/frontend/src/views/cluster/Nodes.vue
@@ -46,7 +46,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 </template>
 
 <script type="ts">
-import { getContext } from '../../router';
+import { getContext } from '../../context';
 import Watch from '../../components/Watch.vue';
 import TBreadcrumbs from '../../components/TBreadcrumbs.vue';
 import NodeListItem from '../../components/NodeListItem.vue';

--- a/frontend/src/views/cluster/Pods.vue
+++ b/frontend/src/views/cluster/Pods.vue
@@ -76,7 +76,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 </template>
 
 <script type="ts">
-import { getContext } from '../../router';
+import { getContext } from '../../context';
 import Watch from '../../components/Watch.vue';
 import TBreadcrumbs from '../../components/TBreadcrumbs.vue';
 

--- a/frontend/src/views/node/Overview.vue
+++ b/frontend/src/views/node/Overview.vue
@@ -56,7 +56,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 <script type="ts">
 import { useRoute } from 'vue-router';
-import { getContext } from '../../router';
+import { getContext } from '../../context';
 import TBreadcrumbs from '../../components/TBreadcrumbs.vue';
 import TChart from '../../components/TChart.vue';
 

--- a/frontend/src/views/node/Services.vue
+++ b/frontend/src/views/node/Services.vue
@@ -74,7 +74,7 @@ import {
   XCircleIcon,
   ExclamationCircleIcon
 } from '@heroicons/vue/outline';
-import { getContext } from '../../router';
+import { getContext } from '../../context';
 import { useRoute } from 'vue-router';
 
 export default {


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/theila/issues/53

Also fix CAPI upgrade related issues:
- cluster name wasn't passed to the context.
- workaround for the issue of context name being different for `Talos` and
`Kubernetes` runtimes. Do not extract cluster name from the context,
just strip `admin@` on the backend in the `Talos` runtime.
- query parameter `name` -> `cluster`.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>