### PR TITLE
refactor: use the same object for gRPC metadata context and messages

### DIFF
--- a/frontend/src/api/resources.ts
+++ b/frontend/src/api/resources.ts
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import { UpgradeK8sSpec, TaskStatusSpec, TaskLogSpec, KubernetesVersionSpec } from './rpc/management';
+
 // Manual definitions for COSI resource types.
 // Would be nice to somehow generate them both for Go and TS, but that's not clear how to do as of now.
 export const UpgradeTaskType = "UpgradeTasks.theila.sidero.dev";
@@ -10,3 +12,37 @@ export const TaskLogType = "TaskLogs.theila.sidero.dev";
 export const KubernetesVersionType = "KubernetesVersions.theila.sidero.dev";
 
 export const DefaultNamespace = "default";
+
+const registeredTypes = {
+  [UpgradeTaskType]: UpgradeK8sSpec,
+  [TaskStatusType]: TaskStatusSpec,
+  [TaskLogType]: TaskLogSpec,
+  [KubernetesVersionType]: KubernetesVersionSpec,
+};
+
+const camelToSnakeCaseKey = str => str.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`);
+const camelToSnakeCase = object => {
+  for(const key in object) {
+    const snake = camelToSnakeCaseKey(key);
+    if(snake !== key) {
+      object[snake] = object[key];
+      delete(object[key]);
+    }
+
+    if(typeof object[key] === "object")
+      camelToSnakeCase(object.key);
+  }
+};
+
+export const encodeProtobuf = (type?: string, spec?: any) => {
+  if(!type)
+    throw new Error("Resource type is not defined");
+
+  camelToSnakeCase(spec);
+
+  const res = registeredTypes[type];
+  if(!res)
+    throw new Error(`Resource ${type} parser is not registered. Please modify ./src/api/resources.ts to add it`);
+
+  return res.encode(res.fromPartial(spec)).finish();
+}

--- a/frontend/src/components/ClusterListItem.vue
+++ b/frontend/src/components/ClusterListItem.vue
@@ -186,7 +186,7 @@ export default {
     };
 
     const upgradeKubernetes = () => {
-      router.replace({
+      router.push({
         query: {
           modal: "upgrade",
           cluster: item.value["metadata"]["name"],

--- a/frontend/src/components/NodeListItem.vue
+++ b/frontend/src/components/NodeListItem.vue
@@ -187,19 +187,21 @@ export default {
     };
 
     const rebootNode = async () => {
-      router.replace({
+      router.push({
         query: {
           modal: "reboot",
           node: ip.value,
+          ...route.query,
         }
       })
     };
 
     const resetNode = async () => {
-      router.replace({
+      router.push({
         query: {
           modal: "reset",
           node: ip.value,
+          ...route.query,
         }
       });
     };

--- a/frontend/src/components/TModal.vue
+++ b/frontend/src/components/TModal.vue
@@ -52,9 +52,7 @@ export default {
       view,
       props,
       close() {
-        router.replace({ query: {
-          modal: undefined,
-        }});
+        router.go(-1);
       }
     }
   }

--- a/frontend/src/context.ts
+++ b/frontend/src/context.ts
@@ -6,7 +6,7 @@ import { ref, Ref } from 'vue';
 import { useRoute } from 'vue-router';
 import { Client } from "./api/client";
 import { ResourceService, RequestError } from './api/grpc';
-import { Runtime } from './api/common/theila.pb';
+import { Context } from './api/common/theila';
 import { Code } from './api/google/rpc/code';
 
 export namespace context {
@@ -34,18 +34,22 @@ export function getContext() {
 
   const name = contextName();
 
-  if(route.query.namespace && route.query.cluster && route.query.uid) {
-    return {
-      cluster: {
-        name: route.query.cluster,
-        namespace: route.query.namespace || "default",
-        uid: route.query.uid
-      },
-      name: name,
+  const res = {};
+  if(name)
+    res["name"] = name;
+
+  if(route.params && route.params.node)
+    res["nodes"] = [route.params.node];
+
+  if(route.query && route.query.namespace && route.query.cluster && route.query.uid) {
+    res["cluster"] = {
+      "name": route.query.cluster,
+      "namespace": route.query.namespace || "default",
+      "uid": route.query.uid
     };
   }
 
-  return name ? { name: name } : null;
+  return Context.fromPartial(res);
 }
 
 export function contextName(): string | null {

--- a/frontend/src/views/Reboot.vue
+++ b/frontend/src/views/Reboot.vue
@@ -27,12 +27,13 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import TButton from '../components/TButton.vue';
 import { ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { MachineService, getCluster } from '../api/grpc';
+import { MachineService } from '../api/grpc';
 import { Runtime } from '../api/common/theila.pb';
 import {
   ExclamationIcon,
 } from '@heroicons/vue/outline';
 import { showError } from '../modal';
+import { getContext } from '../context';
 
 export default {
   components: {
@@ -46,11 +47,11 @@ export default {
     const state = ref("Reboot");
 
     const close = () => {
-      router.replace({ query: {
-        modal: undefined,
-        node: undefined,
-      }});
+      router.go(-1);
     };
+
+    const context = getContext();
+    context.nodes = [route.query.node as string];
 
     return {
       node: route.query.node,
@@ -62,10 +63,7 @@ export default {
         try {
           const res = await MachineService.Reboot({}, {
             runtime: Runtime.Talos,
-            metadata: {
-              nodes: [route.query.node],
-              ...getCluster(route),
-            }
+            context: context,
           });
 
           const errors: string[] = [];

--- a/frontend/src/views/Reset.vue
+++ b/frontend/src/views/Reset.vue
@@ -30,12 +30,13 @@ import TButton from '../components/TButton.vue';
 import TCheckbox from '../components/TCheckbox.vue';
 import { ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { MachineService, getCluster } from '../api/grpc';
+import { MachineService } from '../api/grpc';
 import { Runtime } from '../api/common/theila.pb';
 import {
   ExclamationIcon,
 } from '@heroicons/vue/outline';
 import { showError } from '../modal';
+import { getContext } from '../context';
 
 export default {
   components: {
@@ -52,11 +53,11 @@ export default {
     const reboot = ref(true);
 
     const close = () => {
-      router.replace({ query: {
-        modal: undefined,
-        node: undefined,
-      }});
+      router.go(-1);
     };
+
+    const context = getContext();
+    context.nodes = [route.query.node as string];
 
     return {
       node: route.query.node,
@@ -79,10 +80,7 @@ export default {
               ],
             }, {
             runtime: Runtime.Talos,
-            metadata: {
-              nodes: [route.query.node],
-              ...getCluster(route),
-            }
+            context: context,
           });
 
           const errors: string[] = [];

--- a/frontend/src/views/SidebarNode.vue
+++ b/frontend/src/views/SidebarNode.vue
@@ -54,9 +54,9 @@ import {
   DocumentTextIcon,
 } from '@heroicons/vue/outline';
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue';
-import { ResourceService, getCluster } from '../api/grpc';
+import { ResourceService } from '../api/grpc';
 import { Runtime } from '../api/common/theila.pb';
-import { useRoute } from 'vue-router';
+import { getContext } from '../context';
 
 export default {
   components: {
@@ -73,17 +73,14 @@ export default {
 
   setup() {
     const services: Ref<Object[]> = ref([]);
-    const route = useRoute();
+    const context = getContext();
 
     onMounted(async () => {
       const response = await ResourceService.List({
         type: 'services',
       }, {
-        metadata: {
-          nodes: [route.params.node],
-          ...getCluster(route),
-        },
         runtime: Runtime.Talos,
+        context: context,
       });
 
       for(const message of response) {

--- a/frontend/src/views/SidebarRoot.vue
+++ b/frontend/src/views/SidebarRoot.vue
@@ -106,11 +106,11 @@ export default {
     const router = useRouter();
 
     const openUpgrade = () => {
-      router.replace({query: {modal: "upgrade"}});
+      router.push({query: {modal: "upgrade"}});
     }
 
     const openSettings = () => {
-      router.replace({query: {modal: "settings"}});
+      router.push({query: {modal: "settings"}});
     }
 
     return {

--- a/frontend/src/views/node/Logs.vue
+++ b/frontend/src/views/node/Logs.vue
@@ -21,8 +21,9 @@ import TBreadcrumbs from '../../components/TBreadcrumbs.vue';
 import TAlert from '../../components/TAlert.vue';
 import LogView from '../../components/LogView.vue';
 import { ref, watch, onUnmounted, computed } from 'vue';
-import { MachineService, subscribe, getCluster } from '../../api/grpc';
+import { MachineService, subscribe } from '../../api/grpc';
 import { Runtime } from '../../api/common/theila.pb';
+import { getContext } from '../../context';
 
 export default {
   components: {
@@ -34,6 +35,7 @@ export default {
   setup() {
     const logs = ref([]);
     const route = useRoute();
+    const context = getContext();
 
     let stream = ref(null);
     let buffer = "";
@@ -92,10 +94,7 @@ export default {
         }, 50);
       }, {
         runtime: Runtime.Talos,
-        metadata: {
-          nodes: [route.params.node],
-          ...getCluster(route),
-        },
+        context: context,
       });
     }
 

--- a/frontend/src/views/node/Services.vue
+++ b/frontend/src/views/node/Services.vue
@@ -75,7 +75,6 @@ import {
   ExclamationCircleIcon
 } from '@heroicons/vue/outline';
 import { getContext } from '../../context';
-import { useRoute } from 'vue-router';
 
 export default {
   components: {
@@ -88,18 +87,8 @@ export default {
   },
 
   setup() {
-    const route = useRoute();
-
     return {
-      getContext() {
-        const ctx = getContext() || {};
-
-        ctx.nodes = [
-          route.params.node
-        ];
-
-        return ctx;
-      },
+      getContext,
     }
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/theila/issues/65

Get rid of `getCluster` and replace it with `getContext` everywhere.
Also introduce global types registry to encode outgoing objects in
`Create` and `Update` gRPC calls.
And convert `camelCase` format to `snake_case` to avoid having the mix of them in the request.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>