### PR TITLE
fix: use secure websockets if the page itself is using https

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -99,7 +99,8 @@ export class Client extends EventEmitter {
   // connect opens web socket.
   // should receive the session after that.
   public connect(timeout?: number): Promise<void> {
-    this.ws = new WebSocket("ws://" + this.address + "/ws");
+    const protocol = location.protocol === 'https:' ? 'wss' : 'ws';
+    this.ws = new WebSocket(`${protocol}://${this.address}/ws`);
     this.ws.binaryType = "arraybuffer";
 
     this.ws.onmessage = this.onmessage.bind(this);


### PR DESCRIPTION
This should help when the container runs behind some https ingress.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>