### PR TITLE
fix: properly handle Same-Origin header in websockets

### DIFF
--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -101,7 +101,7 @@ func (s *Server) Run(ctx context.Context) error {
 
 	s.ws = ws.New(s.ctx, mux)
 
-	s.logger.Sugar().Infof("serving on port %d", s.port)
+	s.logger.Sugar().Infof("serving on %s:%d", s.address, s.port)
 
 	server := &http.Server{
 		Addr:    fmt.Sprintf("%s:%d", s.address, s.port),


### PR DESCRIPTION
Default implementation does not consider `x-forwarded-host` header which
breaks `wss` tunnels in some cases.

Besides that, get rid of all `self-hosted` checks, as it doesn't work on newer Talos versions as there is no bootstrap status anymore.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>