### PR TITLE
fix: talosconfig/kubeconfig when using the default context

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -30,7 +30,7 @@ const withPrefix = (prefix, routes) =>
 export function getBreadcrumbs(route) {
   const crumbs:Object[] = [];
 
-  if(route.query.cluster && route.query.uid && route.query.namespace) {
+  if(route.query && route.query.cluster && route.query.uid && route.query.namespace) {
     crumbs.push(
       {
         text: "Clusters",
@@ -41,7 +41,7 @@ export function getBreadcrumbs(route) {
 
   if(route.params.node) {
     crumbs.push(
-      { text: `${route.query.cluster || context.current.value ? context.current.value.cluster : "Current Cluster"} Nodes`, to: {name: "Nodes", query: route.query } },
+      { text: `${route.query.cluster || (context.current.value ? context.current.value.cluster : "Current Cluster")} Nodes`, to: {name: "Nodes", query: route.query } },
     );
   }
 

--- a/frontend/src/views/SidebarRoot.vue
+++ b/frontend/src/views/SidebarRoot.vue
@@ -18,7 +18,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     <disclosure as="template" defaultOpen v-slot="{ open }">
       <disclosure-button as="div" class="disclosure-button">
         MANAGE
-        <chevron-up-icon :class="{ chevron: true, open: open }"/>
+        <chevron-down-icon :class="{ chevron: true, open: open }"/>
       </disclosure-button>
       <disclosure-panel as="template" class="overflow-hidden">
         <shell-menu-item @click="openUpgrade" name="Upgrade Kubernetes">

--- a/internal/backend/grpc/resource.go
+++ b/internal/backend/grpc/resource.go
@@ -7,7 +7,6 @@ package grpc
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/cosi-project/runtime/api/v1alpha1"
 	"github.com/cosi-project/runtime/pkg/resource/protobuf"
@@ -210,9 +209,6 @@ func (s *resourceServer) GetConfig(ctx context.Context, cluster *common.Cluster)
 	}
 
 	context := router.ExtractContext(ctx)
-	if context == nil {
-		return nil, fmt.Errorf("context parameters are required for the config request")
-	}
 
 	res, err := r.GetContext(ctx, context, cluster)
 	if err != nil {

--- a/internal/backend/runtime/kubernetes/kubernetes.go
+++ b/internal/backend/runtime/kubernetes/kubernetes.go
@@ -372,6 +372,10 @@ func (r *Runtime) getOrCreateClient(ctx context.Context, opts *runtime.QueryOpti
 }
 
 func (r *Runtime) getClient(id string) (*client, error) {
+	if id == "" {
+		id = runtime.DefaultClient
+	}
+
 	client := func() *client {
 		r.clientsMu.Lock()
 		defer r.clientsMu.Unlock()
@@ -406,8 +410,13 @@ func (r *Runtime) getClient(id string) (*client, error) {
 		return client, nil
 	}
 
+	ctxID := id
+	if id == runtime.DefaultClient {
+		ctxID = ""
+	}
+
 	// then fall back to the local kubeconfig
-	cfg, err := config.GetConfigWithContext(id)
+	cfg, err := config.GetConfigWithContext(ctxID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Also fix breadcrumbs errors on default context.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>