### PR TITLE
fix: more websocket client bugfixes

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -63,15 +63,19 @@ export default {
     onMounted(async () => {
       await context.api.connect();
 
-      connected.value = true;
-
       const response = await ContextService.List();
 
       if(response.contexts)
         contexts.value = response.contexts;
 
-      if(response.current)
+      if(response.current) {
         currentContext.value = response.current;
+        context.current.value = {
+          name: response.current,
+        };
+      }
+
+      connected.value = true;
 
       await detectCapabilities();
     });


### PR DESCRIPTION
Slower connection and websocket proxy exposed more problems on the
client side reconnect logic:
- closing connection does not abort any pending watch requests so they
time out and incorrectly mark watch as failed.

Also got rid of annoying `subscription does not exist` errors after
reconnect when the server is restarted.
There should be no need to clean up subscriptions if the client has lost
the connection completely as the server should delete the session and
all linked subscriptions.

Found yet another issue with default context usage: was picking default
talos context as well, what is incorrect as per current implementation
Kubernetes context should always be the leading one. Otherwise you may
get your Theila app in the weird state when you set `kubectl config
use-context A` and `talosctl config use-context B`. Fixed that by always
defining the current context whatever is default in `kubeconfig` at the
time when Theila is started.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>