### PR TITLE
fix: properly pass label selector to the metadata in ClusterListItem

### DIFF
--- a/frontend/src/components/ClusterListItem.vue
+++ b/frontend/src/components/ClusterListItem.vue
@@ -136,9 +136,11 @@ export default {
         namespace: item.value.metadata.namespace,
         type: "machines.v1alpha3.cluster.x-k8s.io",
       }, {
-        selectors: [
-          `cluster.x-k8s.io/cluster-name=${item.value.metadata.name}`
-        ]
+        metadata: {
+          selectors: [
+            `cluster.x-k8s.io/cluster-name=${item.value.metadata.name}`
+          ]
+        }
       });
 
       let count = 0;


### PR DESCRIPTION
Format was changed, but this wasn't updated in this particular
component.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>