### PR TITLE
fix: add `frontend/node_modules` to gitignore

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 // THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 //
-// Generated on 2021-10-26T14:12:56Z by kres 83904ad-dirty.
+// Generated on 2021-11-05T12:13:36Z by kres 6a46ad7-dirty.
 
 module.exports = {
   presets: [

--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-10-22T16:23:42Z by kres f6c7130-dirty.
+# Generated on 2021-11-05T12:13:36Z by kres 6a46ad7-dirty.
 
 ---
 policies:
@@ -28,12 +28,10 @@ policies:
   spec:
     skipPaths:
       - .git/
+      - testdata/
     includeSuffixes:
       - .go
     excludeSuffixes:
       - .pb.go
       - .pb.gw.go
-    header: |
-      // This Source Code Form is subject to the terms of the Mozilla Public
-      // License, v. 2.0. If a copy of the MPL was not distributed with this
-      // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    header: "// This Source Code Form is subject to the terms of the Mozilla Public\u000A// License, v. 2.0. If a copy of the MPL was not distributed with this\u000A// file, You can obtain one at http://mozilla.org/MPL/2.0/.\u000A"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-09-23T21:48:27Z by kres ce6bee5-dirty.
+# Generated on 2021-11-05T12:13:36Z by kres 6a46ad7-dirty.
 
 _out
+frontend/node_modules

--- a/.jestrc
+++ b/.jestrc
@@ -1,6 +1,6 @@
 // THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 //
-// Generated on 2021-10-26T14:12:56Z by kres 83904ad-dirty.
+// Generated on 2021-11-05T12:13:36Z by kres 6a46ad7-dirty.
 
 module.exports = {
   preset: '@vue/cli-plugin-unit-jest/presets/typescript-and-babel/',

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -4,7 +4,7 @@
 
 // THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 //
-// Generated on 2021-10-26T14:12:56Z by kres 83904ad-dirty.
+// Generated on 2021-11-05T12:13:36Z by kres 6a46ad7-dirty.
 
 package frontend
 


### PR DESCRIPTION
This folder is now created by `dev-server` command, so it should be
added to `.gitignore`.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>