### PR TITLE
fix: properly set TaskStatus namespace in the initial call

### DIFF
--- a/internal/backend/runtime/theila/controllers/upgrade.go
+++ b/internal/backend/runtime/theila/controllers/upgrade.go
@@ -354,7 +354,7 @@ func (t *upgradeTask) start(ctx context.Context, task *resources.UpgradeK8sTask,
 		return err
 	}
 
-	if err := r.Modify(ctx, resources.NewTaskStatus(Namespace, id), func(res resource.Resource) error {
+	if err := r.Modify(ctx, resources.NewTaskStatus(namespace, id), func(res resource.Resource) error {
 		res.(*resources.TaskStatus).SetVersions(upgradeOptions.FromVersion, upgradeOptions.ToVersion)
 		res.(*resources.TaskStatus).SetPhase(rpc.TaskStatusSpec_RUNNING)
 


### PR DESCRIPTION
Namespace should be the name of the cluster, not `default`.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>