### PR TITLE
fix: invert chart value for cpu, storage and memory on the overview page

### DIFF
--- a/frontend/src/methods/index.ts
+++ b/frontend/src/methods/index.ts
@@ -115,7 +115,7 @@ export const formatBytes = (bytes, decimals = 2) => {
 
   const i = Math.floor(Math.log(bytes) / Math.log(k));
 
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+  return (bytes / Math.pow(k, i)).toFixed(dm) + ' ' + sizes[i];
 }
 
 export const getUpgradeID = async () => {

--- a/frontend/src/views/Overview/components/TOverviewContent.vue
+++ b/frontend/src/views/Overview/components/TOverviewContent.vue
@@ -384,7 +384,7 @@ export default {
       ),
       memoryUsageProcentage: computed(() =>
         (
-          (clusterNodesAllocatableMemory() * 100) /
+          100 - (clusterNodesAllocatableMemory() * 100) /
           clusterNodesCapacityMemory()
         ).toFixed(1)
       ),
@@ -392,11 +392,11 @@ export default {
         formatBytes(clusterNodesCapacityMemory())
       ),
       memoryUsageCurrent: computed(() =>
-        formatBytes(clusterNodesAllocatableMemory())
+        formatBytes(clusterNodesCapacityMemory() - clusterNodesAllocatableMemory())
       ),
       storageUsageProcentage: computed(() =>
         (
-          (clusterNodesAllocatableStorage() * 100) /
+          100 - (clusterNodesAllocatableStorage() * 100) /
           clusterNodesCapacityStorage()
         ).toFixed(1)
       ),
@@ -404,16 +404,16 @@ export default {
         formatBytes(clusterNodesCapacityStorage())
       ),
       storageUsageCurrent: computed(() =>
-        formatBytes(clusterNodesAllocatableStorage())
+        formatBytes(clusterNodesCapacityStorage() - clusterNodesAllocatableStorage())
       ),
       CPUUsageProcentage: computed(() =>
         (
-          (clusterNodesAllocatableCPU() * 100) /
+          100 - (clusterNodesAllocatableCPU() * 100) /
           clusterNodesCapacityCPU()
         ).toFixed(1)
       ),
       CPUUsageTotal: computed(() => clusterNodesCapacityCPU()),
-      CPUUsageCurrent: computed(() => clusterNodesAllocatableCPU()),
+      CPUUsageCurrent: computed(() => (clusterNodesCapacityCPU() - clusterNodesAllocatableCPU()).toFixed(2)),
     };
   },
 };


### PR DESCRIPTION
It was showing capacity instead of used.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>